### PR TITLE
Migrate Hive profile metadata schema

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -80,10 +80,10 @@ const Settings = () => {
   };
 
   const handleRestoreProfile = async () => {
-    if (!userData.hiveUsername || !userData.postingKey) {
+    if (!userData.hiveUsername) {
       toast({
         title: "Missing Credentials",
-        description: "Please log in with posting key",
+        description: "Please log in to your Hive account",
         status: "error",
         duration: 3000,
         isClosable: true,

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -126,10 +126,19 @@ const Settings = () => {
       }
 
       if (postingMetadata.skatehiveuser) delete postingMetadata.skatehiveuser;
-      if (postingMetadata.extensions?.skatehiveuser)
+      if (postingMetadata.extensions?.skatehiveuser) {
         delete postingMetadata.extensions.skatehiveuser;
+        if (Object.keys(postingMetadata.extensions).length === 0) {
+          delete postingMetadata.extensions;
+        }
+      }
       if (jsonMetadata.skatehiveuser) delete jsonMetadata.skatehiveuser;
-      if (jsonMetadata.extensions?.skatehiveuser) delete jsonMetadata.extensions.skatehiveuser;
+      if (jsonMetadata.extensions?.skatehiveuser) {
+        delete jsonMetadata.extensions.skatehiveuser;
+        if (Object.keys(jsonMetadata.extensions).length === 0) {
+          delete jsonMetadata.extensions;
+        }
+      }
 
       const keychain = new KeychainSDK(window);
       const formParams = {

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -12,6 +12,7 @@ import {
   AccordionButton,
   AccordionPanel,
   AccordionIcon,
+  Button,
 } from "@chakra-ui/react";
 import { useTheme, ThemeName, themeMap } from "../themeProvider";
 import LottieAnimation from "@/components/shared/LottieAnimation";
@@ -23,6 +24,7 @@ import VoteWeightSlider from "@/components/settings/VoteWeightSlider";
 import { useAioha } from "@aioha/react-ui";
 import useHiveAccount from "@/hooks/useHiveAccount";
 import useProfileData from "@/hooks/useProfileData";
+import { KeychainSDK, KeychainKeyTypes } from "keychain-sdk";
 
 const Settings = () => {
   const { themeName, setThemeName } = useTheme();
@@ -75,6 +77,93 @@ const Settings = () => {
       .split(/(?=[A-Z])|[-_]/)
       .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
       .join(" ");
+  };
+
+  const handleRestoreProfile = async () => {
+    if (!userData.hiveUsername || !userData.postingKey) {
+      toast({
+        title: "Missing Credentials",
+        description: "Please log in with posting key",
+        status: "error",
+        duration: 3000,
+        isClosable: true,
+      });
+      return;
+    }
+
+    try {
+      const accountResp = await fetch("https://api.hive.blog", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "condenser_api.get_accounts",
+          params: [[userData.hiveUsername]],
+          id: 1,
+        }),
+      }).then((res) => res.json());
+
+      if (!accountResp.result || accountResp.result.length === 0) {
+        throw new Error("Account not found");
+      }
+
+      let postingMetadata: any = {};
+      let jsonMetadata: any = {};
+      try {
+        if (accountResp.result[0].posting_json_metadata) {
+          postingMetadata = JSON.parse(accountResp.result[0].posting_json_metadata);
+        }
+      } catch {
+        postingMetadata = {};
+      }
+
+      try {
+        if (accountResp.result[0].json_metadata) {
+          jsonMetadata = JSON.parse(accountResp.result[0].json_metadata);
+        }
+      } catch {
+        jsonMetadata = {};
+      }
+
+      if (postingMetadata.skatehiveuser) delete postingMetadata.skatehiveuser;
+      if (postingMetadata.extensions?.skatehiveuser)
+        delete postingMetadata.extensions.skatehiveuser;
+      if (jsonMetadata.skatehiveuser) delete jsonMetadata.skatehiveuser;
+      if (jsonMetadata.extensions?.skatehiveuser) delete jsonMetadata.extensions.skatehiveuser;
+
+      const keychain = new KeychainSDK(window);
+      const formParams = {
+        data: {
+          username: userData.hiveUsername,
+          operations: [
+            [
+              "account_update2",
+              {
+                account: userData.hiveUsername,
+                posting_json_metadata: JSON.stringify(postingMetadata),
+                json_metadata: JSON.stringify(jsonMetadata),
+                extensions: [],
+              },
+            ],
+          ],
+          method: KeychainKeyTypes.active,
+        },
+      };
+
+      const result = await keychain.broadcast(formParams.data as any);
+      if (!result) {
+        throw new Error("Profile restore failed");
+      }
+
+      toast({ title: "Profile Restored", status: "success", duration: 3000 });
+    } catch (err: any) {
+      toast({
+        title: "Restore Failed",
+        description: err?.message || "Unable to restore profile",
+        status: "error",
+        duration: 3000,
+      });
+    }
   };
 
   const buttonSources = [
@@ -158,6 +247,17 @@ const Settings = () => {
                 // Vote weight updated
               }}
             />
+          )}
+
+          {/* Restore Profile Button */}
+          {userData.hiveUsername && (
+            <Button
+              onClick={handleRestoreProfile}
+              colorScheme="red"
+              variant="outline"
+            >
+              Restore Profile
+            </Button>
           )}
 
           {/* Farcaster Account Link */}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -126,19 +126,9 @@ const Settings = () => {
       }
 
       if (postingMetadata.skatehiveuser) delete postingMetadata.skatehiveuser;
-      if (postingMetadata.extensions?.skatehiveuser) {
-        delete postingMetadata.extensions.skatehiveuser;
-        if (Object.keys(postingMetadata.extensions).length === 0) {
-          delete postingMetadata.extensions;
-        }
-      }
+      if (postingMetadata.extensions) delete postingMetadata.extensions;
       if (jsonMetadata.skatehiveuser) delete jsonMetadata.skatehiveuser;
-      if (jsonMetadata.extensions?.skatehiveuser) {
-        delete jsonMetadata.extensions.skatehiveuser;
-        if (Object.keys(jsonMetadata.extensions).length === 0) {
-          delete jsonMetadata.extensions;
-        }
-      }
+      if (jsonMetadata.extensions) delete jsonMetadata.extensions;
 
       const keychain = new KeychainSDK(window);
       const formParams = {

--- a/components/layout/AuthButton.tsx
+++ b/components/layout/AuthButton.tsx
@@ -171,6 +171,18 @@ export default function AuthButton() {
         migrated.extensions.farcaster = migrated.extensions.farcaster || {};
         migrated.extensions.farcaster.username = farcasterProfile.username;
         migrated.extensions.farcaster.fid = farcasterProfile.fid;
+
+        migrated.extensions.wallets = migrated.extensions.wallets || {};
+        if (farcasterProfile.custody) {
+          migrated.extensions.wallets.custody_address = farcasterProfile.custody;
+        }
+        if (
+          Array.isArray(farcasterProfile.verifications) &&
+          farcasterProfile.verifications.length > 0
+        ) {
+          migrated.extensions.wallets.farcaster_verified_wallets =
+            farcasterProfile.verifications;
+        }
       }
 
       const operation: Operation = [

--- a/components/layout/AuthButton.tsx
+++ b/components/layout/AuthButton.tsx
@@ -151,12 +151,22 @@ export default function AuthButton() {
       }
 
       let currentMetadata: any = {};
+      let postingMetadata: any = {};
       try {
         if (accountResp.result[0].json_metadata) {
           currentMetadata = JSON.parse(accountResp.result[0].json_metadata);
         }
       } catch {
         // ignore parse errors
+      }
+      try {
+        if (accountResp.result[0].posting_json_metadata) {
+          postingMetadata = JSON.parse(
+            accountResp.result[0].posting_json_metadata
+          );
+        }
+      } catch {
+        postingMetadata = {};
       }
 
       const migrated = migrateLegacyMetadata(currentMetadata);
@@ -171,6 +181,16 @@ export default function AuthButton() {
         migrated.extensions.farcaster = migrated.extensions.farcaster || {};
         migrated.extensions.farcaster.username = farcasterProfile.username;
         migrated.extensions.farcaster.fid = farcasterProfile.fid;
+        if (farcasterProfile.pfpUrl) {
+          migrated.extensions.farcaster.pfp_url = farcasterProfile.pfpUrl;
+          postingMetadata.profile = postingMetadata.profile || {};
+          postingMetadata.profile.profile_image = farcasterProfile.pfpUrl;
+        }
+        if (farcasterProfile.bio) {
+          migrated.extensions.farcaster.bio = farcasterProfile.bio;
+          postingMetadata.profile = postingMetadata.profile || {};
+          postingMetadata.profile.about = farcasterProfile.bio;
+        }
 
         migrated.extensions.wallets = migrated.extensions.wallets || {};
         if (farcasterProfile.custody) {
@@ -190,8 +210,7 @@ export default function AuthButton() {
         {
           account: user,
           json_metadata: JSON.stringify(migrated),
-          posting_json_metadata:
-            accountResp.result[0].posting_json_metadata || "{}",
+          posting_json_metadata: JSON.stringify(postingMetadata),
           extensions: [],
         },
       ];

--- a/components/profile/MergeAccountModal.tsx
+++ b/components/profile/MergeAccountModal.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+  Button,
+  Text,
+} from "@chakra-ui/react";
+
+interface MergeAccountModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onMerge: () => void;
+}
+
+const MergeAccountModal: React.FC<MergeAccountModalProps> = ({
+  isOpen,
+  onClose,
+  onMerge,
+}) => (
+  <Modal isOpen={isOpen} onClose={onClose} isCentered>
+    <ModalOverlay />
+    <ModalContent>
+      <ModalHeader>Merge Account Data</ModalHeader>
+      <ModalCloseButton />
+      <ModalBody>
+        <Text>
+          We found existing profile data on Hive. Would you like to merge it with
+          your connected account?
+        </Text>
+      </ModalBody>
+      <ModalFooter>
+        <Button variant="ghost" mr={3} onClick={onClose}>
+          Cancel
+        </Button>
+        <Button colorScheme="green" onClick={onMerge}>
+          Merge
+        </Button>
+      </ModalFooter>
+    </ModalContent>
+  </Modal>
+);
+
+export default MergeAccountModal;

--- a/hooks/useFarcasterSession.ts
+++ b/hooks/useFarcasterSession.ts
@@ -36,6 +36,7 @@ export function useFarcasterSession() {
         fid: profile.fid,
         username: profile.username,
         pfpUrl: profile.pfpUrl,
+        bio: profile.bio,
         displayName: profile.displayName,
         custody: profile.custody,
         verifications: profile.verifications,

--- a/hooks/useFarcasterSession.ts
+++ b/hooks/useFarcasterSession.ts
@@ -9,6 +9,15 @@ interface FarcasterSession {
   pfpUrl?: string;
   bio?: string;
   displayName?: string;
+  /**
+   * Farcaster custody address associated with the user.
+   * Included when restoring a session from Auth Kit.
+   */
+  custody?: `0x${string}`;
+  /**
+   * Array of verified wallet addresses for this Farcaster account.
+   */
+  verifications?: string[];
   timestamp: number;
 }
 
@@ -28,6 +37,8 @@ export function useFarcasterSession() {
         username: profile.username,
         pfpUrl: profile.pfpUrl,
         displayName: profile.displayName,
+        custody: profile.custody,
+        verifications: profile.verifications,
         timestamp: Date.now(),
       };
       localStorage.setItem(SESSION_KEY, JSON.stringify(session));

--- a/lib/utils/metadataMigration.ts
+++ b/lib/utils/metadataMigration.ts
@@ -1,0 +1,94 @@
+import { DEFAULT_VOTE_WEIGHT } from './constants';
+import { SkatehiveJsonMetadata } from '@/types/ProfileMetadata';
+
+export function isLegacyMetadata(data: any): boolean {
+  if (!data || !data.extensions) return false;
+  const ext = data.extensions;
+  return (
+    ext.eth_address !== undefined ||
+    ext.vote_weight !== undefined ||
+    ext.farcasterName !== undefined ||
+    ext.fid !== undefined ||
+    ext.level !== undefined ||
+    ext.staticXp !== undefined ||
+    ext.cumulativeXp !== undefined
+  );
+}
+
+export function migrateLegacyMetadata(data: any): SkatehiveJsonMetadata {
+  const metadata: SkatehiveJsonMetadata = {
+    ...data,
+    profile: data?.profile || {},
+    extensions: data?.extensions || {}
+  };
+
+  const ext: any = metadata.extensions;
+
+  // Wallet migrations
+  if (ext.eth_address) {
+    ext.wallets = ext.wallets || {};
+    ext.wallets.primary_wallet = ext.eth_address;
+    delete ext.eth_address;
+  }
+  if (ext.btc_address) {
+    ext.wallets = ext.wallets || {};
+    ext.wallets.btc_address = ext.btc_address;
+    delete ext.btc_address;
+  }
+
+  if (ext.vote_weight !== undefined) {
+    ext.settings = ext.settings || {};
+    ext.settings.voteSettings = ext.settings.voteSettings || {
+      default_voting_weight: DEFAULT_VOTE_WEIGHT * 100,
+      enable_slider: true
+    };
+    ext.settings.voteSettings.default_voting_weight = Math.round(
+      Number(ext.vote_weight) * 100
+    );
+    delete ext.vote_weight;
+  }
+
+  if (ext.disable_slider !== undefined) {
+    ext.settings = ext.settings || {};
+    ext.settings.voteSettings = ext.settings.voteSettings || {
+      default_voting_weight: DEFAULT_VOTE_WEIGHT * 100,
+      enable_slider: true
+    };
+    ext.settings.voteSettings.enable_slider = !ext.disable_slider;
+    delete ext.disable_slider;
+  }
+
+  if (ext.farcasterName || ext.fid) {
+    ext.farcaster = ext.farcaster || {};
+    if (ext.farcasterName) {
+      ext.farcaster.username = ext.farcasterName;
+      delete ext.farcasterName;
+    }
+    if (ext.fid) {
+      ext.farcaster.fid = Number(ext.fid);
+      delete ext.fid;
+    }
+  }
+
+  delete ext.level;
+  delete ext.staticXp;
+  delete ext.cumulativeXp;
+
+  // Ensure substructures exist
+  ext.wallets = ext.wallets || {};
+  ext.wallets.additional = ext.wallets.additional || [];
+  ext.wallets.farcaster_verified_wallets =
+    ext.wallets.farcaster_verified_wallets || [];
+
+  ext.settings = ext.settings || {};
+  ext.settings.voteSettings = ext.settings.voteSettings || {
+    default_voting_weight: DEFAULT_VOTE_WEIGHT * 100,
+    enable_slider: true
+  };
+  ext.settings.appSettings = ext.settings.appSettings || {};
+
+  ext.other = ext.other || {};
+
+  metadata.extensions = ext;
+  return metadata;
+}

--- a/types/ProfileMetadata.ts
+++ b/types/ProfileMetadata.ts
@@ -11,6 +11,8 @@ export interface SkatehiveExtensions {
   farcaster?: {
     fid?: number;
     username?: string;
+    pfp_url?: string;
+    bio?: string;
   };
   video_parts?: VideoPart[];
   other?: Record<string, any>;

--- a/types/ProfileMetadata.ts
+++ b/types/ProfileMetadata.ts
@@ -1,0 +1,43 @@
+export interface SkatehiveVideoPart {
+  name: string;
+  filmmaker: string[];
+  friends: string[];
+  year: string;
+  url: string;
+}
+
+export interface SkatehiveExtensions {
+  wallets?: {
+    primary_wallet?: string;
+    custody_address?: string;
+    farcaster_verified_wallets?: string[];
+    additional?: string[];
+    btc_address?: string;
+  };
+  farcaster?: {
+    fid?: number;
+    username?: string;
+  };
+  video_parts?: SkatehiveVideoPart[];
+  other?: Record<string, any>;
+  settings?: {
+    voteSettings?: {
+      default_voting_weight: number;
+      enable_slider: boolean;
+    };
+    appSettings?: Record<string, any>;
+  };
+}
+
+export interface SkatehiveJsonMetadata {
+  profile?: {
+    name?: string;
+    about?: string;
+    location?: string;
+    website?: string;
+    profile_image?: string;
+    cover_image?: string;
+    version?: number;
+  };
+  extensions?: SkatehiveExtensions;
+}

--- a/types/ProfileMetadata.ts
+++ b/types/ProfileMetadata.ts
@@ -1,10 +1,4 @@
-export interface SkatehiveVideoPart {
-  name: string;
-  filmmaker: string[];
-  friends: string[];
-  year: string;
-  url: string;
-}
+import { VideoPart } from './VideoPart';
 
 export interface SkatehiveExtensions {
   wallets?: {
@@ -18,7 +12,7 @@ export interface SkatehiveExtensions {
     fid?: number;
     username?: string;
   };
-  video_parts?: SkatehiveVideoPart[];
+  video_parts?: VideoPart[];
   other?: Record<string, any>;
   settings?: {
     voteSettings?: {


### PR DESCRIPTION
## Summary
- add metadata migration utilities and types
- update profile editing and vote weight components to use new schema
- parse vote weight from nested settings
- show merge modal when user connects wallet

## Testing
- `pnpm lint`
- `pnpm build` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6886452f3d14832cb937e46ee0699899