### PR TITLE
Add shared fetchAccount helper

### DIFF
--- a/components/settings/AdvancedSettings.tsx
+++ b/components/settings/AdvancedSettings.tsx
@@ -18,6 +18,7 @@ import {
   AlertDescription,
 } from "@chakra-ui/react";
 import { KeychainSDK, KeychainKeyTypes } from "keychain-sdk";
+import fetchAccount from "@/lib/hive/fetchAccount";
 
 interface AdvancedSettingsProps {
   userData: {
@@ -42,40 +43,9 @@ const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({ userData }) => {
     }
 
     try {
-      const accountResp = await fetch("https://api.hive.blog", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          method: "condenser_api.get_accounts",
-          params: [[userData.hiveUsername]],
-          id: 1,
-        }),
-      }).then((res) => res.json());
-
-      if (!accountResp.result || accountResp.result.length === 0) {
-        throw new Error("Account not found");
-      }
-
-      let postingMetadata: any = {};
-      let jsonMetadata: any = {};
-      try {
-        if (accountResp.result[0].posting_json_metadata) {
-          postingMetadata = JSON.parse(
-            accountResp.result[0].posting_json_metadata
-          );
-        }
-      } catch {
-        postingMetadata = {};
-      }
-
-      try {
-        if (accountResp.result[0].json_metadata) {
-          jsonMetadata = JSON.parse(accountResp.result[0].json_metadata);
-        }
-      } catch {
-        jsonMetadata = {};
-      }
+      const { postingMetadata, jsonMetadata } = await fetchAccount(
+        userData.hiveUsername
+      );
 
       if (postingMetadata.skatehiveuser) delete postingMetadata.skatehiveuser;
       if (postingMetadata.extensions) delete postingMetadata.extensions;

--- a/components/settings/VoteWeightSlider.tsx
+++ b/components/settings/VoteWeightSlider.tsx
@@ -22,6 +22,7 @@ import { DEFAULT_VOTE_WEIGHT } from "@/lib/utils/constants";
 import { migrateLegacyMetadata } from "@/lib/utils/metadataMigration";
 import { Operation } from "@hiveio/dhive";
 import { useVoteWeightContext } from "@/contexts/VoteWeightContext";
+import fetchAccount from "@/lib/hive/fetchAccount";
 
 interface VoteWeightSliderProps {
   username: string;
@@ -79,31 +80,9 @@ const VoteWeightSlider: React.FC<VoteWeightSliderProps> = ({
       const keychain = new KeychainSDK(window);
 
       // Get current profile metadata
-      const accounts = await fetch(`https://api.hive.blog`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          method: "condenser_api.get_accounts",
-          params: [[username]],
-          id: 1,
-        }),
-      }).then((res) => res.json());
-
-      if (!accounts.result || accounts.result.length === 0) {
-        throw new Error("Account not found");
-      }
-
-      const account = accounts.result[0];
-      let currentMetadata: any = {};
-
-      try {
-        if (account.json_metadata) {
-          currentMetadata = JSON.parse(account.json_metadata);
-        }
-      } catch (error) {
-        console.log("No existing metadata or invalid JSON");
-      }
+      const { account, jsonMetadata: currentMetadata } = await fetchAccount(
+        username
+      );
 
       const migrated = migrateLegacyMetadata(currentMetadata);
       migrated.extensions = migrated.extensions || {};

--- a/lib/hive/fetchAccount.ts
+++ b/lib/hive/fetchAccount.ts
@@ -1,0 +1,58 @@
+import { Account } from '@hiveio/dhive'
+
+export interface AccountData {
+  account: Account
+  jsonMetadata: Record<string, any>
+  postingMetadata: Record<string, any>
+}
+
+/**
+ * Fetch a Hive account and parse its metadata.
+ */
+export async function fetchAccount(username: string): Promise<AccountData> {
+  const response = await fetch('https://api.hive.blog', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'condenser_api.get_accounts',
+      params: [[username]],
+      id: 1,
+    }),
+  })
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch Hive account')
+  }
+
+  const accountResp = await response.json()
+
+  if (!accountResp.result || accountResp.result.length === 0) {
+    throw new Error('Account not found')
+  }
+
+  const account: Account = accountResp.result[0]
+
+  let jsonMetadata: Record<string, any> = {}
+  let postingMetadata: Record<string, any> = {}
+
+  try {
+    if (account.json_metadata) {
+      jsonMetadata = JSON.parse(account.json_metadata)
+    }
+  } catch {
+    jsonMetadata = {}
+  }
+
+  try {
+    if (account.posting_json_metadata) {
+      postingMetadata = JSON.parse(account.posting_json_metadata)
+    }
+  } catch {
+    postingMetadata = {}
+  }
+
+  return { account, jsonMetadata, postingMetadata }
+}
+
+export default fetchAccount


### PR DESCRIPTION
## Summary
- add `fetchAccount` helper to handle Hive RPC calls and metadata parsing
- use the new helper in profile editing and authentication components
- update advanced settings and vote weight slider to leverage the helper

## Testing
- `pnpm lint`
- `pnpm build` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6886d8aa4f6c832c9a4884514b3cc5f4