### PR TITLE
Add GitHub Codespaces support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "Skatehive 3.0",
+  "image": "mcr.microsoft.com/devcontainers/base:debian",
+  "remoteUser": "vscode",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    }
+  },
+  "postCreateCommand": "pnpm install",
+  "forwardPorts": [3000],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  }
+}
+

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ Open `http://localhost:3000` in your browser.
 
 Run `pnpm lint` to check lint rules and `pnpm build` to create a production build.
 
+## GitHub Codespaces
+
+This repo contains a `.devcontainer` folder so you can work in
+[GitHub Codespaces](https://github.com/features/codespaces). Launch a
+new codespace from the **Code** menu on GitHub and the container will
+install dependencies with `pnpm install` and forward port `3000` for the
+Next.js dev server. The container installs Node.js 20 with pnpm 9 via the
+official Node feature so the environment matches local development.
+Once setup completes, run `pnpm dev` to launch the application.
+
 ## Environment Variables
 
 The app relies on a number of environment variables. The most common ones are provided in `.env.local.example`:


### PR DESCRIPTION
## Summary
- switch devcontainer to Node feature and run as `vscode`
- document Node 20 with pnpm 9 for Codespaces

## Testing
- `pnpm lint` *(warnings only)*
- `pnpm build` *(fails: Creating an optimized production build ...)*

------
https://chatgpt.com/codex/tasks/task_e_68882c90446c832cab407185c283cc88