### PR TITLE
Add Zora API key placeholder

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -58,3 +58,6 @@ NEXT_PUBLIC_GOVERNOR= 0x3b7c72033cf4d8c5c85d58612a6661c2d70f4010                
 NEXT_PUBLIC_DOMAIN=skatehive.app          # Used for Farcaster Auth Kit
 
 # Add any additional variables needed by your features below.
+
+# --- ZORA ---
+NEXT_PUBLIC_ZORA_API_KEY=

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Additional variables used by specific features:
 - `ADMIN_USERS` – comma-separated list of usernames with admin privileges for Farcaster notifications (e.g., `user1,user2,user3`)
 - `PINATA_API_KEY` and `PINATA_SECRET_API_KEY` – upload media to Pinata/IPFS
 - `GIPHY_API_KEY` – GIF search in the composer
+- `NEXT_PUBLIC_ZORA_API_KEY` – obtain a Zora API key to enable Zora embeds
 - `EMAIL_USER`, `EMAIL_PASS`, `EMAIL_COMMUNITY`, `EMAIL_RECOVERYACC` – sending invite emails
 - `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLIC_KEY`, `SUPABASE_PRIVATE_KEY` – Supabase integration
 - Ethereum/Wagmi keys such as `NEXT_PUBLIC_WC_PROJECT_ID`, `ETHERSCAN_API_KEY`, `NEXT_PUBLIC_ALCHEMY_KEY` and DAO addresses (`NEXT_PUBLIC_TOKEN`, `NEXT_PUBLIC_METADATA`, `NEXT_PUBLIC_AUCTION`, `NEXT_PUBLIC_TREASURY`, `NEXT_PUBLIC_GOVERNOR`)


### PR DESCRIPTION
## Summary
- add placeholder for `NEXT_PUBLIC_ZORA_API_KEY` to `.env.local.example`
- document obtaining a Zora API key in README

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6888d9f57d78832ca6bcded0bc65d01e