### PR TITLE
Add Zora coin previews in posts

### DIFF
--- a/components/markdown/EnhancedMarkdownRenderer.tsx
+++ b/components/markdown/EnhancedMarkdownRenderer.tsx
@@ -5,6 +5,7 @@ import {
 } from "@/lib/markdown/MarkdownProcessor";
 import { VideoEmbed } from "./VideoEmbed";
 import InstagramEmbed from "./InstagramEmbed";
+import ZoraCoinPreview from "./ZoraCoinPreview";
 import HiveMarkdown from "@/components/shared/HiveMarkdown";
 
 interface EnhancedMarkdownRendererProps {
@@ -32,7 +33,7 @@ function renderContentWithVideos(
 ): React.ReactNode[] {
   // Split on all supported video and social media placeholders
   const parts = processed.contentWithPlaceholders.split(
-    /(\[\[(VIDEO|ODYSEE|YOUTUBE|VIMEO|INSTAGRAM):([^\]]+)\]\])/g
+    /(\[\[(VIDEO|ODYSEE|YOUTUBE|VIMEO|INSTAGRAM|ZORACOIN):([^\]]+)\]\])/g
   );
 
   return parts
@@ -54,6 +55,13 @@ function renderContentWithVideos(
       if (instagramMatch) {
         const url = instagramMatch[1];
         return <InstagramEmbed key={`instagram-${idx}`} url={url} />;
+      }
+
+      // Handle Zora coin placeholders
+      const zoraMatch = part.match(/^\[\[ZORACOIN:([^\]]+)\]\]$/);
+      if (zoraMatch) {
+        const addr = zoraMatch[1];
+        return <ZoraCoinPreview key={`zora-${idx}`} address={addr} />;
       }
 
       // Skip empty parts or parts that are just whitespace

--- a/components/markdown/ZoraCoinPreview.tsx
+++ b/components/markdown/ZoraCoinPreview.tsx
@@ -1,0 +1,79 @@
+import { Box, HStack, Image, Link, Text } from "@chakra-ui/react";
+import { useEffect, useState } from "react";
+
+interface ZoraCoinPreviewProps {
+  address: string;
+}
+
+interface TokenData {
+  name?: string;
+  symbol?: string;
+  image?: string;
+  price?: number;
+}
+
+export default function ZoraCoinPreview({ address }: ZoraCoinPreviewProps) {
+  const [token, setToken] = useState<TokenData | null>(null);
+
+  useEffect(() => {
+    let ignore = false;
+    async function fetchData() {
+      try {
+        const res = await fetch(
+          `https://api.zora.co/api/v0/token/metadata?contractAddress=${address}`,
+          {
+            headers: {
+              "Accept": "application/json",
+              "X-API-KEY": process.env.NEXT_PUBLIC_ZORA_API_KEY || "",
+            },
+          }
+        );
+        if (!res.ok) return;
+        const json = await res.json();
+        if (!ignore) {
+          setToken({
+            name: json?.token?.name,
+            symbol: json?.token?.symbol,
+            image: json?.token?.image,
+            price: json?.token?.lastPriceEth,
+          });
+        }
+      } catch {
+        // ignore errors in preview
+      }
+    }
+    fetchData();
+    return () => {
+      ignore = true;
+    };
+  }, [address]);
+
+  if (!token) return null;
+
+  return (
+    <Box
+      border="1px"
+      borderColor="gray.600"
+      borderRadius="md"
+      p={3}
+      my={4}
+    >
+      <HStack spacing={3} align="center">
+        {token.image && (
+          <Image src={token.image} alt={token.name} boxSize="40px" borderRadius="full" />
+        )}
+        <Box>
+          <Link href={`https://zora.co/coin/${address}`} isExternal fontWeight="bold">
+            {token.name || address}
+          </Link>
+          {token.symbol && (
+            <Text fontSize="sm" color="gray.400">
+              {token.symbol} {token.price ? `- ${token.price} ETH` : ""}
+            </Text>
+          )}
+        </Box>
+      </HStack>
+    </Box>
+  );
+}
+

--- a/lib/markdown/MarkdownProcessor.ts
+++ b/lib/markdown/MarkdownProcessor.ts
@@ -27,8 +27,11 @@ export class MarkdownProcessor {
     // Step 1: Process media content (from existing MarkdownRenderer)
     const processedContent = processMediaContent(content);
 
+    // Insert placeholders after Zora coin links
+    const withZora = this.addZoraCoinPlaceholders(processedContent);
+
     // Step 2: Extract video placeholders and convert to our format
-    const contentWithPlaceholders = this.convertToVideoPlaceholders(processedContent);
+    const contentWithPlaceholders = this.convertToVideoPlaceholders(withZora);
 
     // Step 3: Detect Instagram embeds
     const hasInstagramEmbeds = processedContent.includes("<!--INSTAGRAM_EMBED_SCRIPT-->");
@@ -74,5 +77,12 @@ export class MarkdownProcessor {
 
   static clearCache(): void {
     markdownProcessingCache.clear();
+  }
+
+  private static addZoraCoinPlaceholders(content: string): string {
+    return content.replace(
+      /(https:\/\/zora\.co\/coin\/([a-zA-Z0-9:]+))/g,
+      (_match, url, addr) => `${url} [[ZORACOIN:${addr}]]`
+    );
   }
 }


### PR DESCRIPTION
## Summary
- detect `zora.co/coin/...` links when rendering markdown
- insert `[[ZORACOIN:<address>]]` placeholders in MarkdownProcessor
- render `ZoraCoinPreview` component when placeholder found
- implement `ZoraCoinPreview` to fetch token info from Zora API

## Testing
- `pnpm lint`
- `pnpm build` *(fails to build sitemap after timeout but compilation succeeded)*

------
https://chatgpt.com/codex/tasks/task_e_6888e0f85994832c967593ab56e9f42e