### PR TITLE
Integrate RainbowKit for wallet connections

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
+@import "@rainbow-me/rainbowkit/styles.css";
+
 /* Import markdown styles */
 @import '../styles/markdown.css';
 

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -4,9 +4,12 @@ import { CSSReset } from "@chakra-ui/react";
 import { Aioha } from "@aioha/aioha";
 import { AiohaProvider } from "@aioha/react-ui";
 import { ThemeProvider } from "./themeProvider";
-import { OnchainKitProvider } from "@coinbase/onchainkit";
-import { WagmiProvider, http, createConfig } from "wagmi";
+import { WagmiProvider, http } from "wagmi";
 import { base, mainnet } from "wagmi/chains";
+import {
+  RainbowKitProvider,
+  getDefaultConfig,
+} from "@rainbow-me/rainbowkit";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { UserProvider } from "@/contexts/UserContext";
 import { VoteWeightProvider } from "@/contexts/VoteWeightContext";
@@ -28,12 +31,15 @@ if (typeof window !== "undefined") {
 
 const queryClient = new QueryClient();
 
-export const wagmiConfig = createConfig({
+export const wagmiConfig = getDefaultConfig({
+  appName: "Skatehive",
+  projectId: process.env.NEXT_PUBLIC_WC_PROJECT_ID || "",
   chains: [base, mainnet],
   transports: {
     [base.id]: http(),
     [mainnet.id]: http(),
   },
+  ssr: true,
 });
 
 const farcasterAuthConfig = {
@@ -50,11 +56,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       <ThemeProvider>
         <QueryClientProvider client={queryClient}>
           <WagmiProvider config={wagmiConfig}>
-            <OnchainKitProvider
-              chain={base}
-              apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY}
-              projectId={process.env.NEXT_PUBLIC_CDP_PROJECT_ID}
-            >
+            <RainbowKitProvider>
               <AuthKitProvider config={farcasterAuthConfig}>
                 <AiohaProvider aioha={aioha}>
                   <VoteWeightProvider>
@@ -63,7 +65,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
                   </VoteWeightProvider>
                 </AiohaProvider>
               </AuthKitProvider>
-            </OnchainKitProvider>
+            </RainbowKitProvider>
           </WagmiProvider>
         </QueryClientProvider>
       </ThemeProvider>

--- a/components/layout/ConnectionModal.tsx
+++ b/components/layout/ConnectionModal.tsx
@@ -20,7 +20,8 @@ import {
 } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { useAioha } from "@aioha/react-ui";
-import { useAccount, useConnect, useDisconnect } from "wagmi";
+import { useAccount, useDisconnect } from "wagmi";
+import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { useFarcasterSession } from "@/hooks/useFarcasterSession";
 import { useFarcasterMiniapp } from "@/hooks/useFarcasterMiniapp";
 import { useSignIn } from "@farcaster/auth-kit";
@@ -96,7 +97,7 @@ export default function ConnectionModal({
   const toast = useToast();
   // Get connection states
   const { isConnected: isEthereumConnected } = useAccount();
-  const { connect, connectors } = useConnect();
+  const { openConnectModal } = useConnectModal();
   const { disconnect } = useDisconnect();
   const {
     isAuthenticated: isFarcasterConnected,
@@ -151,13 +152,9 @@ export default function ConnectionModal({
     });
   };
 
-  const handleEthereumConnect = async () => {
+  const handleEthereumConnect = () => {
     try {
-      const connector = connectors[0];
-      if (connector) {
-        connect({ connector });
-        onClose();
-      }
+      openConnectModal?.();
     } catch (error) {
       toast({
         status: "error",

--- a/components/profile/EditProfile.tsx
+++ b/components/profile/EditProfile.tsx
@@ -22,7 +22,8 @@ import {
 } from "@chakra-ui/react";
 import countryList from "react-select-country-list";
 import { ProfileData } from "./ProfilePage";
-import { useAccount, useConnect, useDisconnect } from "wagmi";
+import { useAccount, useDisconnect } from "wagmi";
+import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { useAioha } from "@aioha/react-ui";
 import { useFarcasterSession } from "@/hooks/useFarcasterSession";
 import { KeychainSDK, KeychainKeyTypes, Broadcast } from "keychain-sdk";
@@ -56,7 +57,7 @@ const EditProfile: React.FC<EditProfileProps> = React.memo(
     const [isSaving, setIsSaving] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const { address, isConnected } = useAccount();
-    const { connect, connectors, isPending } = useConnect();
+    const { openConnectModal } = useConnectModal();
     const { disconnect } = useDisconnect();
     const { user } = useAioha();
     const { isAuthenticated: isFarcasterConnected, profile: farcasterProfile } =
@@ -406,19 +407,14 @@ const EditProfile: React.FC<EditProfileProps> = React.memo(
               {/* Custom wallet connection instead of ConnectButton */}
               {!isConnected ? (
                 <VStack spacing={2} align="stretch">
-                  {connectors.map((connector) => (
-                    <Button
-                      key={connector.id}
-                      onClick={() => connect({ connector })}
-                      isLoading={isPending}
-                      loadingText="Connecting..."
-                      size="sm"
-                      colorScheme="blue"
-                      variant="outline"
-                    >
-                      Connect {connector.name}
-                    </Button>
-                  ))}
+                  <Button
+                    onClick={() => openConnectModal?.()}
+                    size="sm"
+                    colorScheme="blue"
+                    variant="outline"
+                  >
+                    Connect Wallet
+                  </Button>
                 </VStack>
               ) : (
                 <VStack spacing={2} align="stretch">
@@ -500,9 +496,7 @@ const EditProfile: React.FC<EditProfileProps> = React.memo(
       isEditingEthAddress,
       isConnected,
       address,
-      connectors,
-      isPending,
-      connect,
+      openConnectModal,
       disconnect,
       handleConnectEthWallet,
       handleEditEthAddress,

--- a/components/shared/CoinCreationModal.tsx
+++ b/components/shared/CoinCreationModal.tsx
@@ -538,7 +538,7 @@ export function CoinCreationModal({
               <Alert status="warning" borderRadius="md">
                 <AlertIcon />
                 <Text fontSize="sm">
-                  Please connect your wallet to create coins. Make sure you're
+                  Please connect your wallet to create coins. Make sure you&apos;re
                   on the Base network.
                 </Text>
               </Alert>
@@ -549,7 +549,7 @@ export function CoinCreationModal({
                 <AlertIcon />
                 <VStack align="start" spacing={2}>
                   <Text fontSize="sm">
-                    You're connected to the wrong network. Please switch to Base
+                    You&apos;re connected to the wrong network. Please switch to Base
                     network to create coins.
                   </Text>
                   <Button

--- a/components/wallet/ConnectButton.tsx
+++ b/components/wallet/ConnectButton.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { Wallet, ConnectWallet } from "@coinbase/onchainkit/wallet";
-import { Avatar, Name } from "@coinbase/onchainkit/identity";
-import { Box, Text, Icon } from "@chakra-ui/react";
-import { FaEthereum } from "react-icons/fa";
+import { ConnectButton as RainbowConnectButton } from "@rainbow-me/rainbowkit";
+import { Box } from "@chakra-ui/react";
 import { useAccount } from "wagmi";
 
 export default function ConnectButton() {
@@ -14,51 +12,8 @@ export default function ConnectButton() {
   }
 
   return (
-    <Wallet>
-      <Box
-        as={ConnectWallet}
-        w="full"
-        bg="muted"
-        border="2px solid"
-        borderColor="primary"
-        borderRadius="xl"
-        p={4}
-        minH="80px"
-        transition="all 0.3s ease"
-        _hover={{
-          bg: "primary",
-          color: "background",
-        }}
-        cursor="pointer"
-        display="flex"
-        alignItems="center"
-        justifyContent="center"
-        sx={{
-          "& > div": {
-            display: "none !important",
-          },
-        }}
-      >
-        <Box
-          display="flex"
-          alignItems="center"
-          gap={4}
-          w="full"
-          justifyContent="center"
-          position="absolute"
-          zIndex={10}
-        >
-          <Icon as={FaEthereum} boxSize={6} color="inherit" />
-          <Box display="flex" flexDirection="column" alignItems="start">
-            <Text fontSize="sm" fontWeight="semibold" color="inherit">
-              Connect Ethereum
-            </Text>
-            <Text fontSize="xs" color="inherit" fontWeight="medium">
-              🛹 Join the session
-            </Text>
-          </Box>
-        </Box>
-      </Box>
-    </Wallet>
+    <Box w="full">
+      <RainbowConnectButton chainStatus="icon" />
+    </Box>
   );
 }

--- a/components/wallet/ConnectModal.tsx
+++ b/components/wallet/ConnectModal.tsx
@@ -13,7 +13,7 @@ import {
   Box,
   Center,
 } from "@chakra-ui/react";
-import { Wallet, ConnectWallet } from "@coinbase/onchainkit/wallet";
+import { ConnectButton } from "@rainbow-me/rainbowkit";
 import {
   Identity,
   Avatar,
@@ -100,15 +100,7 @@ export default function ConnectModal({
                 💰 Wallet Connection
               </Text>
               <Center>
-                <Wallet>
-                  <ConnectWallet
-                    disconnectedLabel="Connect Wallet"
-                    onConnect={onClose}
-                  >
-                    <Avatar className="h-8 w-8" />
-                    <Name />
-                  </ConnectWallet>
-                </Wallet>
+                <ConnectButton />
               </Center>
             </Box>
 


### PR DESCRIPTION
## Summary
- load RainbowKit styles in global CSS
- setup RainbowKitProvider with getDefaultConfig and remove obsolete chains prop
- swap OnchainKit wallet connects with RainbowKit modal and button
- adjust connection flows for profile and connection modals
- escape apostrophes causing lint errors

## Testing
- `pnpm lint`
- `NODE_OPTIONS=--max_old_space_size=4096 pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688d3a7335cc832cb519224c47cb70ff