### PR TITLE
Fix Leaderboard sort by posts score and points

### DIFF
--- a/app/RootLayoutClient.tsx
+++ b/app/RootLayoutClient.tsx
@@ -16,28 +16,7 @@ import { Providers } from "./providers";
 import { NotificationProvider } from "@/contexts/NotificationContext";
 import { Analytics } from "@vercel/analytics/next";
 import InitFrameSDK from "@/hooks/init-frame-sdk";
-
-// Type for skater data
-interface SkaterData {
-  id: number;
-  hive_author: string;
-  hive_balance: number;
-  hp_balance: number;
-  hbd_balance: number;
-  hbd_savings_balance: number;
-  has_voted_in_witness: boolean;
-  eth_address: string;
-  gnars_balance: number;
-  gnars_votes: number;
-  skatehive_nft_balance: number;
-  max_voting_power_usd: number;
-  last_updated: string;
-  last_post: string;
-  post_count: number;
-  points: number;
-  giveth_donations_usd: number;
-  giveth_donations_amount: number;
-}
+import { SkaterData } from "@/types/leaderboard";
 
 export default function RootLayoutClient({
   children,

--- a/app/leaderboard/leaderboardClient.tsx
+++ b/app/leaderboard/leaderboardClient.tsx
@@ -28,26 +28,31 @@ import AirdropModal from "@/components/airdrop/AirdropModal";
 import React from "react";
 import useIsMobile from "@/hooks/useIsMobile";
 import { Name } from "@coinbase/onchainkit/identity";
-interface SkaterData {
-  id: number;
-  hive_author: string;
-  hive_balance: number;
-  hp_balance: number;
-  hbd_balance: number;
-  hbd_savings_balance: number;
-  has_voted_in_witness: boolean;
-  eth_address: string;
-  gnars_balance: number;
-  gnars_votes: number;
-  skatehive_nft_balance: number;
-  max_voting_power_usd: number;
-  last_updated: string;
-  last_post: string;
-  post_count: number;
-  points: number;
-  giveth_donations_usd: number;
-  giveth_donations_amount: number;
-}
+import { SkaterData } from "./page";
+
+// interface SkaterData {
+//   id: number;
+//   hive_author: string;
+//   hive_balance: number;
+//   hp_balance: number;
+//   hbd_balance: number;
+//   hbd_savings_balance: number;
+//   has_voted_in_witness: boolean;
+//   eth_address: string;
+//   gnars_balance: number;
+//   gnars_votes: number;
+//   skatehive_nft_balance: number;
+//   max_voting_power_usd: number;
+//   last_updated: string;
+//   last_post: string;
+//   post_count: number;
+//   posts_score: number;
+//   snaps_count: number;
+//   delegated_curator: number;
+//   points: number;
+//   giveth_donations_usd: number;
+//   giveth_donations_amount: number;
+// }
 
 interface Props {
   skatersData: SkaterData[];
@@ -147,7 +152,7 @@ export default function LeaderboardClient({ skatersData }: Props) {
                 {!isMobile &&
                   skater.eth_address &&
                   skater.eth_address !==
-                    "0x0000000000000000000000000000000000000000" && (
+                  "0x0000000000000000000000000000000000000000" && (
                     <EthAddress address={skater.eth_address} />
                   )}
                 {!isMobile && (
@@ -213,7 +218,10 @@ export default function LeaderboardClient({ skatersData }: Props) {
             (a.hp_balance + a.max_voting_power_usd)
           );
         case "posts":
-          return b.post_count - a.post_count;
+          if (a.posts_score === 0 && b.posts_score === 0) {
+            return b.points - a.points; // fallback to points
+          }
+          return b.posts_score - a.posts_score;
         case "nfts":
           return b.skatehive_nft_balance - a.skatehive_nft_balance;
         case "gnars":

--- a/app/leaderboard/leaderboardClient.tsx
+++ b/app/leaderboard/leaderboardClient.tsx
@@ -28,31 +28,7 @@ import AirdropModal from "@/components/airdrop/AirdropModal";
 import React from "react";
 import useIsMobile from "@/hooks/useIsMobile";
 import { Name } from "@coinbase/onchainkit/identity";
-import { SkaterData } from "./page";
-
-// interface SkaterData {
-//   id: number;
-//   hive_author: string;
-//   hive_balance: number;
-//   hp_balance: number;
-//   hbd_balance: number;
-//   hbd_savings_balance: number;
-//   has_voted_in_witness: boolean;
-//   eth_address: string;
-//   gnars_balance: number;
-//   gnars_votes: number;
-//   skatehive_nft_balance: number;
-//   max_voting_power_usd: number;
-//   last_updated: string;
-//   last_post: string;
-//   post_count: number;
-//   posts_score: number;
-//   snaps_count: number;
-//   delegated_curator: number;
-//   points: number;
-//   giveth_donations_usd: number;
-//   giveth_donations_amount: number;
-// }
+import { SkaterData } from "@/types/leaderboard";
 
 interface Props {
   skatersData: SkaterData[];
@@ -241,7 +217,7 @@ export default function LeaderboardClient({ skatersData }: Props) {
             b.eth_address !== "0x0000000000000000000000000000000000000000";
 
           if (aHasEth === bHasEth) {
-            return b.post_count - a.post_count; // Same ETH status, sort by activity
+            return b.posts_score - a.posts_score; // Same ETH status, sort by activity
           }
           return aHasEth ? 1 : -1; // Users without ETH rank higher
         case "gnars_balance":
@@ -252,7 +228,7 @@ export default function LeaderboardClient({ skatersData }: Props) {
           // Sort by post count first, then by witness vote presence
           // This shows active users who haven't voted for witness
           if (a.has_voted_in_witness === b.has_voted_in_witness) {
-            return b.post_count - a.post_count; // Same witness status, sort by activity
+            return b.posts_score - a.posts_score; // Same witness status, sort by activity
           }
           return a.has_voted_in_witness ? 1 : -1; // Users without witness vote rank higher
         case "last_updated":
@@ -347,7 +323,7 @@ export default function LeaderboardClient({ skatersData }: Props) {
     {
       key: "posts",
       label: "Posts Score",
-      value: (skater: SkaterData) => skater.post_count,
+      value: (skater: SkaterData) => skater.posts_score,
     },
   ];
 
@@ -377,7 +353,7 @@ export default function LeaderboardClient({ skatersData }: Props) {
     {
       key: "posts",
       label: "Posts Score",
-      value: (skater: SkaterData) => skater.post_count,
+      value: (skater: SkaterData) => skater.posts_score,
     },
     {
       key: "nfts",

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -17,6 +17,9 @@ interface SkaterData {
   last_updated: string;
   last_post: string;
   post_count: number;
+  posts_score: number;
+  snaps_count: number;
+  delegated_curator: number;
   points: number;
   giveth_donations_usd: number;
   giveth_donations_amount: number;

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -1,29 +1,6 @@
 import { Metadata } from "next";
 import LeaderboardClient from "./leaderboardClient";
-
-export interface SkaterData {
-  id: number;
-  hive_author: string;
-  hive_balance: number;
-  hp_balance: number;
-  hbd_balance: number;
-  hbd_savings_balance: number;
-  has_voted_in_witness: boolean;
-  eth_address: string;
-  gnars_balance: number;
-  gnars_votes: number;
-  skatehive_nft_balance: number;
-  max_voting_power_usd: number;
-  last_updated: string;
-  last_post: string;
-  post_count: number;
-  posts_score: number;
-  snaps_count: number;
-  delegated_curator: number;
-  points: number;
-  giveth_donations_usd: number;
-  giveth_donations_amount: number;
-}
+import { SkaterData } from "@/types/leaderboard";
 
 interface LeaderboardDataResult {
   data: SkaterData[];

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from "next";
 import LeaderboardClient from "./leaderboardClient";
 
-interface SkaterData {
+export interface SkaterData {
   id: number;
   hive_author: string;
   hive_balance: number;

--- a/components/airdrop/AirdropFilterModal.tsx
+++ b/components/airdrop/AirdropFilterModal.tsx
@@ -60,8 +60,8 @@ const AirdropFilterModal: React.FC<AirdropFilterModalProps> = ({
       description: "Users with most HBD in savings",
     },
     {
-      value: "post_count",
-      label: "Post Count",
+      value: "posts_score",
+      label: "Posts Score",
       description: "Most active content creators",
     },
     {

--- a/components/airdrop/AirdropManager.tsx
+++ b/components/airdrop/AirdropManager.tsx
@@ -32,13 +32,14 @@ import { useAccount, useChainId, useSwitchChain } from "wagmi";
 import { useAioha } from "@aioha/react-ui";
 import { KeychainSDK, KeychainKeyTypes } from "keychain-sdk";
 import { Operation } from "@hiveio/dhive";
-import { SkaterData, SortOption } from "@/types/airdrop";
+import { SortOption } from "@/types/airdrop";
 import { tokenDictionary } from "@/lib/utils/tokenDictionary";
 import { useAirdropManager } from "@/hooks/useAirdropManager";
 import { useTransactionStatus } from "@/hooks/useTransactionStatus";
 import { ERC20AirdropService } from "@/services/erc20Airdrop";
 import TransactionStatusDisplay from "./TransactionStatusDisplay";
 import { base } from "wagmi/chains";
+import { SkaterData } from "@/types/leaderboard";
 
 interface AirdropManagerProps {
   leaderboardData: SkaterData[];

--- a/components/airdrop/AirdropModal.tsx
+++ b/components/airdrop/AirdropModal.tsx
@@ -27,7 +27,7 @@ import {
   generateAnnouncementContent,
 } from "../../services/airdropAnnouncement";
 import { captureAirdropNetworkScreenshot } from "@/lib/utils/screenshotCapture";
-import { SkaterData, SortOption } from "@/types/airdrop";
+import { SortOption } from "@/types/airdrop";
 import { useAioha } from "@aioha/react-ui";
 import { PortfolioProvider } from "@/contexts/PortfolioContext";
 import {
@@ -38,6 +38,7 @@ import {
   ConfirmationStep,
 } from "./steps";
 import { StepHeader } from "./steps/StepHeader";
+import { SkaterData } from "@/types/leaderboard";
 
 type ModalView =
   | "tokenSelection"

--- a/components/airdrop/steps/ConfigurationStep.tsx
+++ b/components/airdrop/steps/ConfigurationStep.tsx
@@ -117,7 +117,7 @@ export function ConfigurationStep({
                 <option value="hp_balance">Hive Power</option>
                 <option value="hive_balance">Hive Balance</option>
                 <option value="hbd_savings_balance">HBD Savings</option>
-                <option value="post_count">Post Count</option>
+                <option value="posts_score">Posts Score</option>
                 <option value="has_voted_in_witness">Witness Voters</option>
                 <option value="gnars_balance">Gnars Balance</option>
                 <option value="skatehive_nft_balance">SkateHive NFTs</option>
@@ -187,8 +187,8 @@ export function ConfigurationStep({
                   ? "Hive Balance"
                   : sortOption === "hbd_savings_balance"
                   ? "HBD Savings"
-                  : sortOption === "post_count"
-                  ? "post count"
+                  : sortOption === "posts_score"
+                  ? "posts_score"
                   : sortOption === "gnars_balance"
                   ? "Gnars balance"
                   : sortOption === "skatehive_nft_balance"

--- a/components/shared/SearchOverlay.tsx
+++ b/components/shared/SearchOverlay.tsx
@@ -29,7 +29,6 @@ import NoResults from "./search/NoResults";
 
 // Import types and constants
 import {
-  SkaterData,
   PageResult as PageResultType,
   SearchOverlayProps,
 } from "./search/types";
@@ -38,6 +37,7 @@ import {
   COMMAND_PAGES,
   getPopularPages,
 } from "./search/constants";
+import { SkaterData } from "@/types/leaderboard";
 
 export default function SearchOverlay({
   isOpen,

--- a/components/shared/search/SkaterResult.tsx
+++ b/components/shared/search/SkaterResult.tsx
@@ -2,8 +2,7 @@
 
 import React from "react";
 import { Box, HStack, VStack, Text, Avatar, Icon } from "@chakra-ui/react";
-
-import { SkaterData } from "./types";
+import { SkaterData } from "@/types/leaderboard";
 
 interface SkaterResultProps {
   skater: SkaterData;

--- a/components/shared/search/types.ts
+++ b/components/shared/search/types.ts
@@ -1,24 +1,3 @@
-export interface SkaterData {
-  id: number;
-  hive_author: string;
-  hive_balance: number;
-  hp_balance: number;
-  hbd_balance: number;
-  hbd_savings_balance: number;
-  has_voted_in_witness: boolean;
-  eth_address: string;
-  gnars_balance: number;
-  gnars_votes: number;
-  skatehive_nft_balance: number;
-  max_voting_power_usd: number;
-  last_updated: string;
-  last_post: string;
-  post_count: number;
-  points: number;
-  giveth_donations_usd: number;
-  giveth_donations_amount: number;
-}
-
 export interface PageResult {
   title: string;
   path: string;

--- a/hooks/useAirdropManager.ts
+++ b/hooks/useAirdropManager.ts
@@ -1,7 +1,8 @@
 import { useMemo, useCallback } from 'react';
-import { SkaterData, SortOption, AirdropUser, AirdropSummary, AirdropConfig } from '@/types/airdrop';
+import { SortOption, AirdropUser, AirdropSummary, AirdropConfig } from '@/types/airdrop';
 import { tokenDictionary } from '@/lib/utils/tokenDictionary';
 import { SKATEHIVE_HOT_ADDRESS } from '@/lib/utils/constants';
+import { SkaterData } from '@/types/leaderboard';
 
 interface AirdropManagerProps {
   leaderboardData: SkaterData[];
@@ -80,7 +81,7 @@ export const useAirdropManager = ({ leaderboardData, config }: AirdropManagerPro
       const tokenInfo = tokenDictionary[selectedToken];
       const isERC20 = tokenInfo?.network !== 'hive';
       
-      const skateHiveEntry = {
+      const skateHiveEntry: SkaterData = {
         id: -1,
         hive_author: 'skatehive',
         eth_address: SKATEHIVE_HOT_ADDRESS,
@@ -97,6 +98,9 @@ export const useAirdropManager = ({ leaderboardData, config }: AirdropManagerPro
         last_updated: new Date().toISOString(),
         last_post: '',
         post_count: 0,
+        posts_score: 0,
+        snaps_count: 0, 
+        delegated_curator: 0,
         giveth_donations_usd: 0,
         giveth_donations_amount: 0,
       };

--- a/services/airdropAnnouncement.ts
+++ b/services/airdropAnnouncement.ts
@@ -102,7 +102,7 @@ function getSortOptionLabel(sortOption: string): string {
     hp_balance: 'Hive Power',
     hive_balance: 'Hive Balance',
     hbd_savings_balance: 'HBD Savings',
-    post_count: 'Post Count',
+    posts_score: 'Posts Score',
     has_voted_in_witness: 'Witness Voters',
     gnars_balance: 'Gnars Balance',
     skatehive_nft_balance: 'SkateHive NFTs',

--- a/types/airdrop.ts
+++ b/types/airdrop.ts
@@ -1,30 +1,9 @@
-export interface SkaterData {
-  id: number;
-  hive_author: string;
-  hive_balance: number;
-  hp_balance: number;
-  hbd_balance: number;
-  hbd_savings_balance: number;
-  has_voted_in_witness: boolean;
-  eth_address: string;
-  gnars_balance: number;
-  gnars_votes: number;
-  skatehive_nft_balance: number;
-  max_voting_power_usd: number;
-  last_updated: string;
-  last_post: string;
-  post_count: number;
-  points: number;
-  giveth_donations_usd: number;
-  giveth_donations_amount: number;
-}
-
 export type SortOption =
   | "points"
   | "hp_balance" 
   | "hive_balance"
   | "hbd_savings_balance"
-  | "post_count"
+  | "posts_score"
   | "has_voted_in_witness"
   | "gnars_balance"
   | "skatehive_nft_balance"

--- a/types/leaderboard.ts
+++ b/types/leaderboard.ts
@@ -1,0 +1,23 @@
+export interface SkaterData {
+  id: number;
+  hive_author: string;
+  hive_balance: number;
+  hp_balance: number;
+  hbd_balance: number;
+  hbd_savings_balance: number;
+  has_voted_in_witness: boolean;
+  eth_address: string;
+  gnars_balance: number;
+  gnars_votes: number;
+  skatehive_nft_balance: number;
+  max_voting_power_usd: number;
+  last_updated: string;
+  last_post: string;
+  post_count: number;
+  posts_score: number;
+  snaps_count: number;
+  delegated_curator: number;
+  points: number;
+  giveth_donations_usd: number;
+  giveth_donations_amount: number;
+}


### PR DESCRIPTION
This PR updates the sorting logic for posts. On Mondays, since all post scores are reset to zero, we now fall back to using the author’s total points as a secondary sort criteria.

This ensures that content visibility remains balanced even when scores are equal due to the weekly reset.