### PR TITLE
Use typed GraphQL interfaces in auction service

### DIFF
--- a/services/__tests__/auction.types.test.ts
+++ b/services/__tests__/auction.types.test.ts
@@ -1,0 +1,10 @@
+import type { AuctionsQuery, Auction } from '../auction';
+
+// Ensures that query responses contain expected fields at compile time.
+// If the structure changes, TypeScript will raise errors during `pnpm type-check`.
+export const verifyAuctionShape = (data: AuctionsQuery) => {
+  data.auctions.forEach((auction: Auction) => {
+    const tokenId: bigint = auction.token.tokenId;
+    void tokenId;
+  });
+};


### PR DESCRIPTION
## Summary
- add AuctionsQuery interface and strongly type GraphQL responses
- remove `any` casts in auction service and replace with typed generics
- add compile-time type test to assert auctions and tokenId structure

## Testing
- `pnpm lint`
- `pnpm type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a0cbdc1f24832cb14995bd6fc40f13