### PR TITLE
fix: correct skatespots link in footer from /spots to /map

### DIFF
--- a/components/layout/FooterLinks.tsx
+++ b/components/layout/FooterLinks.tsx
@@ -7,7 +7,7 @@ export default function FooterLinks() {
 
   const exploreLinks = [
     { label: t("tricksGuide") || "Tricks Guide", href: "/tricks" },
-    { label: t("skateSpots") || "Skate Spots", href: "/spots" },
+    { label: t("skateSpots") || "Skate Spots", href: "/map" },
     { label: t("latestVideos") || "Latest Videos", href: "/videos" },
     { label: t("skateMap") || "Map", href: "/map" },
     { label: t("skateshops") || "Skateshops", href: "/skateshops" },


### PR DESCRIPTION
## Summary
- The \"Skate Spots\" link in `FooterLinks.tsx` was pointing to `/spots`, a route that doesn't exist, causing a 404 error
- Changed the href from `/spots` to `/map`, which is the correct route (consistent with the Sidebar and FooterNavButtons)

## Test plan
- [ ] Click \"Skate Spots\" in the footer and confirm it navigates to `/map` without 404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the footer navigation link for skate spots to point to the map page instead of the previous destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->