### PR TITLE
fix(swap): resolve connector.getChainId error on ERC-20 swap

### DIFF
--- a/components/wallet/ERC20SwapSection.tsx
+++ b/components/wallet/ERC20SwapSection.tsx
@@ -681,8 +681,8 @@ export default function ERC20SwapSection({ showFeeOption = false, compact = fals
         const hash = await sendTransactionAsync({
           to: tx.to as `0x${string}`,
           data: tx.data as `0x${string}`,
-          value: tx.value ? BigInt(tx.value) : undefined,
-          gas: tx.gas ? BigInt(tx.gas) : undefined,
+          value: BigInt(tx.value ?? 0),
+          gas: tx.gas != null ? BigInt(tx.gas) : undefined,
           chainId,
         });
 

--- a/components/wallet/ERC20SwapSection.tsx
+++ b/components/wallet/ERC20SwapSection.tsx
@@ -643,8 +643,9 @@ export default function ERC20SwapSection({ showFeeOption = false, compact = fals
       });
       toast({ title: "Approval submitted", description: hash, status: "info", duration: 5000, isClosable: true });
       setNeedsApproval(false);
-    } catch (e: any) {
-      toast({ title: "Approval failed", description: e?.shortMessage ?? e?.message, status: "error", duration: 4000, isClosable: true });
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : (e as { shortMessage?: string })?.shortMessage ?? "Unknown error";
+      toast({ title: "Approval failed", description: msg, status: "error", duration: 4000, isClosable: true });
     }
   }, [approvalTarget, sellToken, writeContractAsync, toast]);
 
@@ -676,19 +677,22 @@ export default function ERC20SwapSection({ showFeeOption = false, compact = fals
           return;
         }
 
+        const tx = quote.transaction;
         const hash = await sendTransactionAsync({
-          to: quote.transaction.to,
-          data: quote.transaction.data,
-          value: quote.transaction.value ? BigInt(quote.transaction.value) : undefined,
-          gas: quote.transaction.gas ? BigInt(quote.transaction.gas) : undefined,
+          to: tx.to as `0x${string}`,
+          data: tx.data as `0x${string}`,
+          value: tx.value ? BigInt(tx.value) : undefined,
+          gas: tx.gas ? BigInt(tx.gas) : undefined,
+          chainId,
         });
 
         setTxHash(hash);
         toast({ title: "Swap submitted!", description: hash, status: "success", duration: 6000, isClosable: true });
         setSellAmount("");
         setPrice(null);
-      } catch (e: any) {
-        toast({ title: "Swap failed", description: e?.shortMessage ?? e?.message, status: "error", duration: 4000, isClosable: true });
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : (e as { shortMessage?: string })?.shortMessage ?? "Unknown error";
+        toast({ title: "Swap failed", description: msg, status: "error", duration: 4000, isClosable: true });
       }
     } else {
       // ── Zora bonding curve swap ─────────────────────────────────────


### PR DESCRIPTION
## Problem

Clicking **Swap** on the ERC-20 tab threw `n.connector.getChainId is not a function`, caused by an incompatibility between wagmi v2.16 and the RainbowKit connector — wagmi calls `connector.getChainId()` internally inside `useSendTransaction`, but the connector does not implement that method.

## Fix

Pass `chainId` explicitly to `sendTransactionAsync`. When the chain ID is provided, wagmi skips the internal connector call entirely.

## Additional improvements

- Cast `tx.to` and `tx.data` to `` `0x${string}` `` for correct viem typing
- Replaced `catch (e: any)` with `catch (e: unknown)` and proper type guards in both the swap and approval handlers

## Test plan

- [ ] Connect an EVM wallet (MetaMask) on Base
- [ ] Enter an amount on the ERC-20 swap tab
- [ ] Confirm quote appears and Swap button activates
- [ ] Click Swap — MetaMask transaction popup opens without errors
- [ ] `connector.getChainId is not a function` error no longer appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Enhanced error messages displayed during token swap and approval operations to provide clearer feedback when issues occur.
  - Improved transaction processing to better support multi-network operations and ensure more reliable swap execution.
  - Strengthened type safety for transaction data handling to prevent potential execution errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->