### PR TITLE
fix(swap): friendly error handling for user-rejected transactions

### DIFF
--- a/components/wallet/ERC20SwapSection.tsx
+++ b/components/wallet/ERC20SwapSection.tsx
@@ -9,7 +9,7 @@ import {
 import { keyframes } from "@emotion/react";
 import { FaExchangeAlt, FaInfoCircle, FaSearch, FaChevronDown, FaCheck } from "react-icons/fa";
 import { useAccount, useChainId, useSendTransaction, useWaitForTransactionReceipt, useWriteContract, useSwitchChain } from "wagmi";
-import { parseUnits, parseEther, formatUnits, formatEther, maxUint256, isAddress } from "viem";
+import { parseUnits, parseEther, formatUnits, formatEther, maxUint256, isAddress, UserRejectedRequestError } from "viem";
 import { base } from "wagmi/chains";
 import { getCoin } from "@zoralabs/coins-sdk";
 import { useZoraTrade } from "@/hooks/useZoraTrade";
@@ -388,6 +388,22 @@ function TokenPicker({
   );
 }
 
+// ─── Error helpers ──────────────────────────────────────────────────────────
+
+function isUserRejection(e: unknown): boolean {
+  if (e instanceof UserRejectedRequestError) return true;
+  const text = `${(e as { shortMessage?: string })?.shortMessage ?? ""} ${(e as { message?: string })?.message ?? ""}`.toLowerCase();
+  return text.includes("user denied") || text.includes("user rejected");
+}
+
+function friendlyError(e: unknown): string {
+  return (
+    (e as { shortMessage?: string })?.shortMessage ||
+    (e instanceof Error ? e.message : null) ||
+    "Unknown error"
+  );
+}
+
 // ─── Main Component ───────────────────────────────────────────────────────────
 
 interface ERC20SwapSectionProps {
@@ -644,8 +660,10 @@ export default function ERC20SwapSection({ showFeeOption = false, compact = fals
       toast({ title: "Approval submitted", description: hash, status: "info", duration: 5000, isClosable: true });
       setNeedsApproval(false);
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : (e as { shortMessage?: string })?.shortMessage ?? "Unknown error";
-      toast({ title: "Approval failed", description: msg, status: "error", duration: 4000, isClosable: true });
+      if (isUserRejection(e))
+        toast({ title: "Transaction cancelled", status: "info", duration: 2000, isClosable: true });
+      else
+        toast({ title: "Approval failed", description: friendlyError(e), status: "error", duration: 4000, isClosable: true });
     }
   }, [approvalTarget, sellToken, writeContractAsync, toast]);
 
@@ -691,8 +709,10 @@ export default function ERC20SwapSection({ showFeeOption = false, compact = fals
         setSellAmount("");
         setPrice(null);
       } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : (e as { shortMessage?: string })?.shortMessage ?? "Unknown error";
-        toast({ title: "Swap failed", description: msg, status: "error", duration: 4000, isClosable: true });
+        if (isUserRejection(e))
+          toast({ title: "Transaction cancelled", status: "info", duration: 2000, isClosable: true });
+        else
+          toast({ title: "Swap failed", description: friendlyError(e), status: "error", duration: 4000, isClosable: true });
       }
     } else {
       // ── Zora bonding curve swap ─────────────────────────────────────


### PR DESCRIPTION
## Problem

When a user cancels a swap in MetaMask, the error toast displayed the raw viem \e.message\ which includes the full hex-encoded calldata, producing an unreadable wall of text.

## Fix

Added two helpers to \ERC20SwapSection\:

- \isUserRejection\ - detects cancellations via \instanceof UserRejectedRequestError\ (viem) with a string fallback for connectors that wrap the error differently.
- \riendlyError\ - reads \shortMessage\ from viem errors instead of \message\, keeping toasts readable.

Cancelled transactions now show a brief \Transaction cancelled\ info toast. Real errors still surface with a clean, readable message.

## Test plan

- [ ] Cancel a swap in MetaMask - \Transaction cancelled\ info toast appears, no hex dump
- [ ] Cancel an approval in MetaMask - same neutral toast
- [ ] Trigger a real error (e.g. insufficient balance) - error toast with readable message, no calldata