### PR TITLE
feat(i18n): add missing pt-BR translations

### DIFF
--- a/lib/i18n/locales/es.ts
+++ b/lib/i18n/locales/es.ts
@@ -47,6 +47,8 @@ export const es = {
     magazineTotalRewards: 'Recompensas Totales de la Revista',
     profileNotFound: 'Perfil no encontrado',
     noSnaps: 'Aún no hay snaps.',
+    noFarcasterAccountLinked: 'No hay cuenta de Farcaster vinculada',
+    socialShareDefault: 'Únete a Skatehive - ¡La Comunidad Web3 del Skate!',
   },
   auth: {
     connectWallet: 'Conectar Billetera',
@@ -142,6 +144,22 @@ export const es = {
       noEvmIdentity: 'No hay identidad EVM vinculada.',
       noFarcasterIdentity: 'No hay identidad Farcaster vinculada.',
       noIdentities: 'No se encontraron identidades.',
+    },
+    fields: {
+      username: 'Nombre de usuario',
+      viewMode: 'Modo de vista',
+      isHiveProfile: 'Es perfil Hive',
+      isOwner: 'Es propietario',
+      isUserbaseOwner: 'Es propietario Userbase',
+      canShowHiveViews: 'Puede mostrar vistas Hive',
+      hiveLookupHandle: 'Handle de búsqueda Hive',
+      hiveIdentityHandle: 'Handle de identidad Hive',
+      hivePostsHandle: 'Handle de posts Hive',
+      userbaseMatch: 'Coincidencia Userbase',
+    },
+    values: {
+      true: 'VERDADERO',
+      false: 'FALSO',
     },
     },
   userbaseAuth: {

--- a/lib/i18n/locales/lg.ts
+++ b/lib/i18n/locales/lg.ts
@@ -47,6 +47,8 @@ export const lg = {
     magazineTotalRewards: 'Maggazini Akutegeeza Akakoma',
     profileNotFound: 'Profile terabiddwa',
     noSnaps: 'Tewali snaps naye.',
+    noFarcasterAccountLinked: 'No Farcaster account linked',
+    socialShareDefault: 'Join Skatehive - The Web3 Skateboard Community!',
   },
   auth: {
     connectWallet: 'Okukoboka Ekilinja',
@@ -142,6 +144,22 @@ export const lg = {
       noEvmIdentity: 'Tewali bukakafu bwa EVM bugattiddwa.',
       noFarcasterIdentity: 'Tewali bukakafu bwa Farcaster bugattiddwa.',
       noIdentities: 'Tewali bukakafu bunasangiddwa.',
+    },
+    fields: {
+      username: 'Username',
+      viewMode: 'View Mode',
+      isHiveProfile: 'Is Hive Profile',
+      isOwner: 'Is Owner',
+      isUserbaseOwner: 'Is Userbase Owner',
+      canShowHiveViews: 'Can Show Hive Views',
+      hiveLookupHandle: 'Hive Lookup Handle',
+      hiveIdentityHandle: 'Hive Identity Handle',
+      hivePostsHandle: 'Hive Posts Handle',
+      userbaseMatch: 'Userbase Match',
+    },
+    values: {
+      true: 'TRUE',
+      false: 'FALSE',
     },
     },
   userbaseAuth: {

--- a/lib/i18n/locales/pt-BR.ts
+++ b/lib/i18n/locales/pt-BR.ts
@@ -47,6 +47,8 @@ export const ptBR = {
     magazineTotalRewards: 'Recompensas Totais da Revista',
     profileNotFound: 'Perfil não encontrado',
     noSnaps: 'Nenhum snap ainda.',
+    noFarcasterAccountLinked: 'Nenhuma conta Farcaster vinculada',
+    socialShareDefault: 'Junte-se ao Skatehive - A Comunidade Web3 do Skate!',
   },
   auth: {
     connectWallet: 'Conectar Carteira',
@@ -142,6 +144,22 @@ export const ptBR = {
       noEvmIdentity: 'Nenhuma identidade EVM vinculada.',
       noFarcasterIdentity: 'Nenhuma identidade Farcaster vinculada.',
       noIdentities: 'Nenhuma identidade encontrada.',
+    },
+    fields: {
+      username: 'Nome de usuário',
+      viewMode: 'Modo de visualização',
+      isHiveProfile: 'É perfil Hive',
+      isOwner: 'É proprietário',
+      isUserbaseOwner: 'É proprietário Userbase',
+      canShowHiveViews: 'Pode exibir views Hive',
+      hiveLookupHandle: 'Handle de busca Hive',
+      hiveIdentityHandle: 'Handle de identidade Hive',
+      hivePostsHandle: 'Handle de posts Hive',
+      userbaseMatch: 'Correspondência Userbase',
+    },
+    values: {
+      true: 'VERDADEIRO',
+      false: 'FALSO',
     },
     },
   userbaseAuth: {


### PR DESCRIPTION
Added missing translations for common.noFarcasterAccountLinked, common.socialShareDefault, profileDebug.fields and profileDebug.values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced Portuguese-BR language support with new translation strings for Farcaster account linking, social sharing, and profile debugging features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->