### PR TITLE
fix(toast): prevent UpvoteSnapToast from reappearing after vote or dismiss

### DIFF
--- a/components/homepage/UpvoteSnapToast.tsx
+++ b/components/homepage/UpvoteSnapToast.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useToast } from "@chakra-ui/react";
 import { FaHeart } from "react-icons/fa";
 import useHiveVote from "@/hooks/useHiveVote";
@@ -11,6 +11,31 @@ import { usePeriodicTimer } from "@/hooks/usePeriodicTimer";
 import { TOAST_CONFIG } from "@/config/toast.config";
 import ToastCard from "@/components/shared/ToastCard";
 import { useTranslations } from "@/contexts/LocaleContext";
+
+const SNOOZE_KEY = "upvote_toast_snoozed_until";
+
+function isSnoozeActive(): boolean {
+  try {
+    const snoozedUntil = localStorage.getItem(SNOOZE_KEY);
+    if (!snoozedUntil) return false;
+    const parsed = Number(snoozedUntil);
+    if (isNaN(parsed)) return false;
+    return Date.now() < parsed;
+  } catch (_e) {
+    return false;
+  }
+}
+
+function snoozeToast(): void {
+  try {
+    localStorage.setItem(
+      SNOOZE_KEY,
+      String(Date.now() + TOAST_CONFIG.SNOOZE_DURATION)
+    );
+  } catch (_e) {
+    // localStorage unavailable in SSR or strict private mode
+  }
+}
 
 interface UpvoteSnapToastProps {
   showInterval?: number;
@@ -29,6 +54,9 @@ export default function UpvoteSnapToast({
   const [lastShownTime, setLastShownTime] = useState<number>(0);
   const toast = useToast();
   const { isDesktop, isMounted } = useIsDesktop();
+  // Tracks which permlink was locally confirmed as voted, preventing a delayed
+  // blockchain refetch from resetting hasVoted to false before Hive propagates.
+  const voteConfirmedPermlink = useRef<string | null>(null);
 
   const fetchSnapContainerData = useCallback(async () => {
     if (!canVote) {
@@ -41,16 +69,24 @@ export default function UpvoteSnapToast({
     try {
       const containerInfo = await getLastSnapsContainer();
       if (containerInfo) {
+        // New container = clear local vote confirmation
+        if (containerInfo.permlink !== voteConfirmedPermlink.current) {
+          voteConfirmedPermlink.current = null;
+        }
+
         const postDetails = await getPost(
           containerInfo.author,
           containerInfo.permlink
         );
         setSnapContainer(postDetails);
         if (effectiveUser && postDetails) {
-          const userVote = postDetails.active_votes.some(
+          const onChainVote = postDetails.active_votes.some(
             (v) => v.voter === effectiveUser
           );
-          setHasVoted(userVote);
+          // Preserve locally confirmed vote even if Hive hasn't propagated yet
+          const locallyConfirmed =
+            voteConfirmedPermlink.current === postDetails.permlink;
+          setHasVoted(onChainVote || locallyConfirmed);
         } else {
           setHasVoted(false);
         }
@@ -74,6 +110,9 @@ export default function UpvoteSnapToast({
       );
 
       if (response.success) {
+        // Set ref before state update so concurrent refetches don't race us
+        voteConfirmedPermlink.current = snapContainer.permlink;
+        setHasVoted(true);
         toast({
           title: t('upvoteToast.successTitle'),
           description: t('upvoteToast.successDescription'),
@@ -81,16 +120,17 @@ export default function UpvoteSnapToast({
           duration: 3000,
           isClosable: true,
         });
-        setHasVoted(true);
       } else {
         throw new Error("Vote failed");
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to upvote:", error);
       toast({
         title: t('upvoteToast.failedTitle'),
         description:
-          error.message || t('upvoteToast.errorOccurred'),
+          error instanceof Error
+            ? error.message
+            : t('upvoteToast.errorOccurred'),
         status: "error",
         duration: 5000,
         isClosable: true,
@@ -105,7 +145,8 @@ export default function UpvoteSnapToast({
       !canVote ||
       !snapContainer ||
       hasVoted ||
-      isSnapVoteLoading
+      isSnapVoteLoading ||
+      isSnoozeActive()
     ) {
       return;
     }
@@ -124,29 +165,36 @@ export default function UpvoteSnapToast({
       duration: displayDuration,
       isClosable: true,
       position: "bottom-right",
-      render: ({ onClose }) => (
-        <ToastCard
-          title={t('upvoteToast.supportCommunity')}
-          description={t('upvoteToast.helpSkateHiveDetailed')}
-          detail={`${t('upvoteToast.container')}: ${snapContainer.author}/${snapContainer.permlink}`}
-          icon={<FaHeart size={16} />}
-          primaryButton={{
-            label: t('upvoteToast.upvoteNow'),
-            icon: <FaHeart size={12} />,
-            onClick: async () => {
-              await handleUpvote();
-              onClose();
-            },
-            colorScheme: "blue",
-          }}
-          onClose={onClose}
-        />
-      ),
+      render: ({ onClose }) => {
+        const handleDismiss = () => {
+          snoozeToast();
+          onClose();
+        };
+        return (
+          <ToastCard
+            title={t('upvoteToast.supportCommunity')}
+            description={t('upvoteToast.helpSkateHiveDetailed')}
+            detail={`${t('upvoteToast.container')}: ${snapContainer.author}/${snapContainer.permlink}`}
+            icon={<FaHeart size={16} />}
+            primaryButton={{
+              label: t('upvoteToast.upvoteNow'),
+              icon: <FaHeart size={12} />,
+              onClick: async () => {
+                await handleUpvote();
+                onClose();
+              },
+              colorScheme: "blue",
+            }}
+            onClose={handleDismiss}
+          />
+        );
+      },
     });
 
-    // Auto-close after duration if user hasn't interacted
+    // Auto-close after duration; snooze so the timer doesn't reopen immediately
     setTimeout(() => {
       if (toast.isActive(toastId)) {
+        snoozeToast();
         toast.close(toastId);
       }
     }, displayDuration);

--- a/config/toast.config.ts
+++ b/config/toast.config.ts
@@ -12,6 +12,7 @@ export const TOAST_CONFIG = {
   LOGIN_WITNESS_DELAY: 2000, // Show witness toast after login
   VOTE_WEIGHT: 10000, // 100% upvote weight
   DESKTOP_BREAKPOINT: 768, // md breakpoint
+  SNOOZE_DURATION: 30 * 60 * 1000, // Dismiss snooze duration (30 minutes)
 } as const;
 
 export const TOAST_STYLES = {


### PR DESCRIPTION
## Summary

- Add `voteConfirmedPermlink` ref to guard against delayed Hive blockchain propagation overwriting the optimistic `hasVoted` state on refetch — fixes the toast reappearing after the user already voted
- Set ref before `setHasVoted` so concurrent `visibilitychange` refetches cannot race the state update
- Add localStorage snooze (30 min) on both explicit dismiss (X button) and auto-close, so the toast stops being insistent when the user ignores it
- Clear local confirmation automatically when a new container permlink is detected
- Extract `isSnoozeActive`/`snoozeToast` as pure module-level functions (no `useCallback` with empty deps)
- Move `SNOOZE_DURATION` into `TOAST_CONFIG` for consistency with other timing constants
- Replace `catch (error: any)` with `unknown` + `instanceof Error` type guard
- Add `isNaN` guard on `Number()` parse of localStorage snooze timestamp

## Root cause

Two independent issues combined:
1. **Race condition** — after a successful vote, any `fetchSnapContainerData()` call (e.g. via `visibilitychange`) would re-fetch `active_votes` from Hive. Since blockchain propagation can take a few seconds, the vote wasn't in `active_votes` yet, causing `setHasVoted(false)` to overwrite the optimistic `true`. The periodic timer would then show the toast again.
2. **No dismiss persistence** — closing the toast without voting left no record; the toast reappeared after 120 seconds.

## Test plan

- [ ] Vote on the container → toast should not reappear in the same session
- [ ] Tab away and back (triggers `visibilitychange` refetch) after voting → toast should stay gone
- [ ] Dismiss toast with X → toast should not reappear for 30 minutes
- [ ] Let toast auto-close (16 s) without interacting → toast should not reappear for 30 minutes
- [ ] Reload page after voting → if Hive has propagated the vote, `active_votes` check keeps toast gone; if not yet propagated, snooze covers the gap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added snooze functionality for upvote notifications. Users can now dismiss the upvote confirmation toast and prevent it from reappearing for 30 minutes, providing a less intrusive notification experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->