### PR TITLE
feat(homepage): add mobile-first SpotNearYou dialog

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -75,3 +75,6 @@ yarn-error.log*
 .npmrc
 .yarnrc
 vercel.json
+
+# Claude local config
+.claude/

--- a/app/HomePageClient.tsx
+++ b/app/HomePageClient.tsx
@@ -9,7 +9,8 @@ import { Discussion } from "@hiveio/dhive";
 import Conversation from "@/components/homepage/Conversation";
 import SnapReplyModal from "@/components/homepage/SnapReplyModal";
 import { useSnaps } from "@/hooks/useSnaps";
-import { HIVE_CONFIG } from "@/config/app.config";
+import { HIVE_CONFIG } from "@/config/app.config"
+import SpotNearYouDialog from "@/components/homepage/SpotNearYouDialog";
 
 export default function HomePageClient() {
   const thread_author = HIVE_CONFIG.THREADS.AUTHOR;
@@ -34,6 +35,7 @@ export default function HomePageClient() {
 
   return (
     <Flex direction={{ base: "column", md: "row" }} justifyContent="center">
+      <SpotNearYouDialog />
       <Box
         maxH="100vh"
         overflowY="auto"

--- a/components/homepage/SpotNearYouDialog.tsx
+++ b/components/homepage/SpotNearYouDialog.tsx
@@ -1,0 +1,124 @@
+"use client"
+
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalBody,
+  Box,
+  Text,
+  Button,
+  Flex,
+  Spinner,
+} from "@chakra-ui/react"
+import { useRouter } from "next/navigation"
+import Image from "next/image"
+import { useState, useEffect } from "react"
+import { useTranslations } from "@/contexts/LocaleContext"
+import { useSpotNearYou, getSpotImage, getSpotTitle } from "@/hooks/useSpotNearYou"
+
+const STORAGE_KEY = "skatehive_spot_dialog_seen"
+
+export default function SpotNearYouDialog() {
+  const [isOpen, setIsOpen] = useState(false)
+  const { displaySpot, isLoading } = useSpotNearYou()
+  const router = useRouter()
+  const t = useTranslations("spotWidget")
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    if (window.innerWidth >= 768) return
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      const elapsed = Date.now() - parseInt(stored, 10)
+      if (elapsed < 24 * 60 * 60 * 1000) return
+    }
+    setIsOpen(true)
+  }, [])
+
+  function dismiss() {
+    localStorage.setItem(STORAGE_KEY, String(Date.now()))
+    setIsOpen(false)
+  }
+
+  function goToMap() {
+    dismiss()
+    router.push("/map")
+  }
+
+  if (!isOpen) return null
+
+  const image = displaySpot ? getSpotImage(displaySpot) : ""
+  const title = displaySpot ? getSpotTitle(displaySpot, t("noName")) : ""
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={dismiss}
+      isCentered
+      motionPreset="slideInBottom"
+      blockScrollOnMount={false}
+    >
+      <ModalOverlay bg="blackAlpha.800" />
+      <ModalContent
+        bg="rgba(10,10,10,0.97)"
+        borderRadius="0"
+        borderWidth="1px"
+        borderColor="whiteAlpha.200"
+        mx={4}
+      >
+        <ModalBody p={0}>
+          {isLoading ? (
+            <Flex justify="center" align="center" height="200px">
+              <Spinner size="md" color="primary" />
+            </Flex>
+          ) : (
+            <Box position="relative" width="100%" height="200px">
+              {image && (
+                <Image
+                  src={image}
+                  alt={title}
+                  fill
+                  style={{ objectFit: "cover" }}
+                  sizes="100vw"
+                />
+              )}
+            </Box>
+          )}
+          <Box p={4}>
+            <Text fontSize="sm" fontWeight="600" color="primary" mb={2}>
+              {t("dialogTitle")}
+            </Text>
+            {!isLoading && (
+              <Text fontSize="md" fontWeight="600" color="white" mb={4} noOfLines={2}>
+                {title}
+              </Text>
+            )}
+            <Flex gap={3}>
+              <Button
+                flex={1}
+                size="sm"
+                colorScheme="green"
+                borderRadius="0"
+                onClick={goToMap}
+              >
+                {t("viewOnMap")}
+              </Button>
+              <Button
+                flex={1}
+                size="sm"
+                variant="outline"
+                borderRadius="0"
+                color="whiteAlpha.700"
+                borderColor="whiteAlpha.300"
+                onClick={dismiss}
+              >
+                {t("dismiss")}
+              </Button>
+            </Flex>
+          </Box>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/hooks/useSpotNearYou.ts
+++ b/hooks/useSpotNearYou.ts
@@ -1,0 +1,125 @@
+"use client"
+
+import { useMemo, useState, useEffect } from "react"
+import { Discussion } from "@hiveio/dhive"
+
+const MAX_NEARBY_KM = 50
+
+export function getSpotImage(spot: Discussion): string {
+  try {
+    const match = spot.body?.match(/!\[.*?\]\((https?:\/\/[^\s)]+)\)/)
+    if (match?.[1]) return match[1]
+  } catch {}
+  return ""
+}
+
+export function getSpotTitle(spot: Discussion, fallback: string): string {
+  try {
+    const match = spot.body?.match(/Spot Name:\s*(.+)/i)
+    if (match?.[1]) return match[1].trim()
+  } catch {}
+  return spot.title || fallback
+}
+
+function isValidCoord(lat: number, lng: number): boolean {
+  return !isNaN(lat) && !isNaN(lng) && Math.abs(lat) <= 90 && Math.abs(lng) <= 180
+}
+
+export function parseSpotCoords(spot: Discussion): { lat: number; lng: number } | null {
+  const body = spot.body || ""
+  const patterns: RegExp[] = [
+    /🌐\s*([-\d.]+),\s*([-\d.]+)/,
+    /Location:\s*([-\d.]+),\s*([-\d.]+)/i,
+    /[!?&]3d([-\d.]+)[!&]4d([-\d.]+)/,
+    /google\.com\/maps[^\s]*@([-\d.]+),([-\d.]+)/,
+    /google\.com\/maps[^\s]*[?&]q=([-\d.]+),([-\d.]+)/,
+    /google\.com\/maps[^\s]*[?&]ll=([-\d.]+),([-\d.]+)/,
+  ]
+  for (const re of patterns) {
+    try {
+      const m = body.match(re)
+      if (m?.[1] && m?.[2]) {
+        const lat = parseFloat(m[1]), lng = parseFloat(m[2])
+        if (isValidCoord(lat, lng)) return { lat, lng }
+      }
+    } catch {}
+  }
+  try {
+    const meta = JSON.parse((spot as any).json_metadata || "{}")
+    const loc = meta?.location
+    if (loc) {
+      const lat = parseFloat(loc.lat ?? loc.latitude)
+      const lng = parseFloat(loc.lng ?? loc.longitude)
+      if (isValidCoord(lat, lng)) return { lat, lng }
+    }
+    const coords = meta?.coordinates
+    if (Array.isArray(coords) && coords.length >= 2) {
+      const lat = coords[1], lng = coords[0]
+      if (isValidCoord(lat, lng)) return { lat, lng }
+    }
+  } catch {}
+  return null
+}
+
+function haversineDistance(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 6371
+  const dLat = ((lat2 - lat1) * Math.PI) / 180
+  const dLng = ((lng2 - lng1) * Math.PI) / 180
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180) * Math.sin(dLng / 2) ** 2
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+}
+
+export interface SpotNearYouState {
+  displaySpot: Discussion | null
+  isNearby: boolean
+  isLoading: boolean
+}
+
+export function useSpotNearYou(): SpotNearYouState {
+  const [spots, setSpots] = useState<Discussion[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [userCoords, setUserCoords] = useState<{ lat: number; lng: number } | null>(null)
+
+  useEffect(() => {
+    fetch("/api/skatespots?page=1&limit=500")
+      .then((r) => r.json())
+      .then((data) => { if (data.success) setSpots(data.data) })
+      .catch(() => {})
+      .finally(() => setIsLoading(false))
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !navigator.geolocation) return
+    navigator.geolocation.getCurrentPosition(
+      (pos) => setUserCoords({ lat: pos.coords.latitude, lng: pos.coords.longitude }),
+      () => setUserCoords(null),
+      { timeout: 5000, maximumAge: 60000 }
+    )
+  }, [])
+
+  const [randomSpot, setRandomSpot] = useState<Discussion | null>(null)
+  useEffect(() => {
+    if (!spots.length) return
+    setRandomSpot(spots[Math.floor(Math.random() * spots.length)])
+  }, [spots])
+
+  const nearestSpot = useMemo(() => {
+    if (!userCoords || !spots.length) return null
+    let closest: Discussion | null = null
+    let minDist = Infinity
+    for (const spot of spots) {
+      const coords = parseSpotCoords(spot)
+      if (!coords) continue
+      const dist = haversineDistance(userCoords.lat, userCoords.lng, coords.lat, coords.lng)
+      if (dist < minDist) { minDist = dist; closest = spot }
+    }
+    return minDist <= MAX_NEARBY_KM ? closest : null
+  }, [spots, userCoords])
+
+  const displaySpot = nearestSpot ?? randomSpot
+  const isNearby = nearestSpot !== null
+
+  return { displaySpot, isNearby, isLoading }
+}

--- a/lib/i18n/locales/en.ts
+++ b/lib/i18n/locales/en.ts
@@ -1180,6 +1180,9 @@ export const en = {
     viewMore: 'view more',
     viewAllSpots: 'view all spots',
     noName: 'Unnamed spot',
+    dialogTitle: 'Spot near you 🛹',
+    viewOnMap: 'view on map',
+    dismiss: 'dismiss',
   },
 };
 

--- a/lib/i18n/locales/es.ts
+++ b/lib/i18n/locales/es.ts
@@ -1197,5 +1197,8 @@ export const es = {
     viewMore: 'ver más',
     viewAllSpots: 'ver todos los spots',
     noName: 'Spot sin nombre',
+    dialogTitle: 'Spot cerca de ti 🛹',
+    viewOnMap: 'ver en el mapa',
+    dismiss: 'descartar',
   },
 };

--- a/lib/i18n/locales/lg.ts
+++ b/lib/i18n/locales/lg.ts
@@ -1196,5 +1196,8 @@ export const lg = {
     viewMore: 'laba nnyini',
     viewAllSpots: 'laba ebifo byonna',
     noName: 'Ekifo tekiinaama',
+    dialogTitle: 'Ekifo eggwanirira 🛹',
+    viewOnMap: 'laba ku mapu',
+    dismiss: 'sazaamu',
   },
 };

--- a/lib/i18n/locales/pt-BR.ts
+++ b/lib/i18n/locales/pt-BR.ts
@@ -1198,5 +1198,8 @@ export const ptBR = {
     viewMore: 'ver mais',
     viewAllSpots: 'ver todos os picos',
     noName: 'Pico sem nome',
+    dialogTitle: 'Pico perto de você 🛹',
+    viewOnMap: 'ver no mapa',
+    dismiss: 'dispensar',
   },
 };


### PR DESCRIPTION
## What's changed
Added a mobile-only dialog that shows once every 24 hours on first visit,
displaying a nearby or random skate spot to encourage map exploration.

## How it works
- Mobile only (hidden on desktop, `window.innerWidth >= 768` check)
- Shows once every 24 hours using localStorage timestamp
- Reuses `useSpotNearYou` hook — geolocation + haversine distance
  - Within 50km → shows nearest spot
  - Beyond 50km or denied → shows random spot
- Two buttons: "View on Map" → `/map`, "Dismiss" → closes dialog
- Fully internationalized (en, pt-BR, es, lg)

## Files changed
- `components/homepage/SpotNearYouDialog.tsx` — new dialog component
- `hooks/useSpotNearYou.ts` — new hook with geolocation + haversine logic
- `app/HomePageClient.tsx` — added dialog to home page
- `lib/i18n/locales/*.ts` — added dialog translation keys

## Screenshots
<img width="1175" height="1808" alt="IMG_7955" src="https://github.com/user-attachments/assets/29da9ced-6fce-4180-bb1a-779457ff669c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "spot near you" dialog on mobile screens highlighting a nearby skate spot with options to view it on the map or dismiss it.
  * Dialog respects user dismissal preferences within 24 hours.

* **Localization**
  * Added translations for the new spot dialog in English, Spanish, Luganda, and Portuguese (Brazil).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SkateHive/skatehive3.0/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->