### PR TITLE
feat(vote): open posting-key dialog when email user lacks Hive key

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -16,6 +16,7 @@ import { VoteWeightProvider } from "@/contexts/VoteWeightContext";
 import { WindowProvider } from "@/contexts/WindowContext";
 import { LocaleProvider } from "@/contexts/LocaleContext";
 import { ReportProvider } from "@/contexts/ReportContext";
+import { PostingKeyDialogProvider } from "@/contexts/PostingKeyDialogContext";
 // import { ClientOnlyAuthKit } from "@/components/providers/ClientOnlyAuthKit"; // Removed: not needed, auth-kit works without global provider
 import { dynamicRainbowTheme } from "@/lib/themes/rainbowkitTheme";
 import { useState, useEffect } from "react";
@@ -109,7 +110,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
                               <FarcasterFrameInit />
                               <UserbaseWalletBootstrapper />
                               <ReportProvider>
-                                {children}
+                                <PostingKeyDialogProvider>
+                                  {children}
+                                </PostingKeyDialogProvider>
                               </ReportProvider>
                             </WindowProvider>
                           </VoteWeightProvider>

--- a/components/userbase/PostingKeyDialog.tsx
+++ b/components/userbase/PostingKeyDialog.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import React from "react";
+import { Box, Text, VStack } from "@chakra-ui/react";
+import SkateModal from "@/components/shared/SkateModal";
+import UserbasePostingKeyPanel from "@/components/userbase/UserbasePostingKeyPanel";
+import { useTranslations } from "@/contexts/LocaleContext";
+
+interface PostingKeyDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  hiveHandle?: string | null;
+}
+
+export default function PostingKeyDialog({
+  isOpen,
+  onClose,
+  hiveHandle,
+}: PostingKeyDialogProps) {
+  const t = useTranslations();
+
+  const description = hiveHandle
+    ? t("postingKeyDialog.descriptionWithHandle").replace(
+        "{handle}",
+        hiveHandle
+      )
+    : t("postingKeyDialog.description");
+
+  return (
+    <SkateModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={t("postingKeyDialog.title")}
+      size={{ base: "full", md: "md" }}
+      windowId="posting-key-dialog"
+    >
+      <Box p={5}>
+        <VStack align="stretch" spacing={4}>
+          <Text color="text" fontSize="sm">
+            {description}
+          </Text>
+          <UserbasePostingKeyPanel variant="modal" />
+        </VStack>
+      </Box>
+    </SkateModal>
+  );
+}

--- a/contexts/PostingKeyDialogContext.tsx
+++ b/contexts/PostingKeyDialogContext.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+import dynamic from "next/dynamic";
+
+const PostingKeyDialog = dynamic(
+  () => import("@/components/userbase/PostingKeyDialog"),
+  { ssr: false }
+);
+
+interface OpenPostingKeyDialogOptions {
+  /** Optional Hive handle to surface in the dialog copy. */
+  hiveHandle?: string | null;
+}
+
+interface PostingKeyDialogContextValue {
+  isOpen: boolean;
+  hiveHandle: string | null;
+  openPostingKeyDialog: (options?: OpenPostingKeyDialogOptions) => void;
+  closePostingKeyDialog: () => void;
+}
+
+const PostingKeyDialogContext =
+  createContext<PostingKeyDialogContextValue | null>(null);
+
+export function PostingKeyDialogProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [hiveHandle, setHiveHandle] = useState<string | null>(null);
+
+  const openPostingKeyDialog = useCallback(
+    (options?: OpenPostingKeyDialogOptions) => {
+      setHiveHandle(options?.hiveHandle ?? null);
+      setIsOpen(true);
+    },
+    []
+  );
+
+  const closePostingKeyDialog = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const value = useMemo<PostingKeyDialogContextValue>(
+    () => ({
+      isOpen,
+      hiveHandle,
+      openPostingKeyDialog,
+      closePostingKeyDialog,
+    }),
+    [isOpen, hiveHandle, openPostingKeyDialog, closePostingKeyDialog]
+  );
+
+  return (
+    <PostingKeyDialogContext.Provider value={value}>
+      {children}
+      {isOpen && (
+        <PostingKeyDialog
+          isOpen={isOpen}
+          onClose={closePostingKeyDialog}
+          hiveHandle={hiveHandle}
+        />
+      )}
+    </PostingKeyDialogContext.Provider>
+  );
+}
+
+export function usePostingKeyDialog() {
+  const context = useContext(PostingKeyDialogContext);
+  if (!context) {
+    // Safe fallback so the hook can be called before the provider mounts
+    // (e.g. during SSR snapshots) without throwing — calls are silent no-ops.
+    return {
+      isOpen: false,
+      hiveHandle: null,
+      openPostingKeyDialog: () => {},
+      closePostingKeyDialog: () => {},
+    } as PostingKeyDialogContextValue;
+  }
+  return context;
+}

--- a/hooks/useHiveVote.ts
+++ b/hooks/useHiveVote.ts
@@ -4,11 +4,15 @@ import { useCallback } from "react";
 import { useAioha } from "@aioha/react-ui";
 import { useLinkedIdentities } from "@/contexts/LinkedIdentityContext";
 import { useUserbaseAuth } from "@/contexts/UserbaseAuthContext";
+import { usePostingKeyDialog } from "@/contexts/PostingKeyDialogContext";
+import { useTranslations } from "@/contexts/LocaleContext";
 
 export default function useHiveVote() {
   const { user, aioha } = useAioha();
   const { hiveIdentity: identity } = useLinkedIdentities();
   const { user: userbaseUser } = useUserbaseAuth();
+  const { openPostingKeyDialog } = usePostingKeyDialog();
+  const t = useTranslations();
 
   const effectiveUser = user || identity?.handle || null;
   const canVote = !!user || !!identity?.handle || !!userbaseUser;
@@ -34,17 +38,18 @@ export default function useHiveVote() {
       });
       const data = await response.json();
       if (!response.ok) {
-        if (data?.code === "POSTING_KEY_NOT_STORED" && identity?.handle) {
-          throw new Error(
-            `Connect your Hive wallet (@${identity.handle}) or add a posting key to vote.`
-          );
+        if (data?.code === "POSTING_KEY_NOT_STORED") {
+          // Surface the posting-key dialog so the user can save their key
+          // and retry the vote, instead of leaving them stuck on a toast.
+          openPostingKeyDialog({ hiveHandle: identity?.handle ?? null });
+          throw new Error(t("upvoteToast.needsPostingKey"));
         }
         throw new Error(data?.error || "Failed to vote");
       }
 
       return { success: true, result: data };
     },
-    [aioha, user]
+    [aioha, user, identity?.handle, openPostingKeyDialog, t]
   );
 
   return { vote, effectiveUser, isWalletConnected: !!user, canVote };

--- a/lib/i18n/locales/en.ts
+++ b/lib/i18n/locales/en.ts
@@ -452,6 +452,14 @@ export const en = {
     helpSkateHiveDetailed: 'Help SkateHive by upvoting the main snap container post where all snaps are stored.',
     container: 'Container',
     upvoteNow: 'Upvote Now',
+    needsPostingKey: 'Add your Hive posting key to vote.',
+    addPostingKey: 'Add posting key',
+  },
+  postingKeyDialog: {
+    title: 'Add your Hive posting key',
+    description: 'Save your Hive posting key so you can vote, comment and post directly under your Hive account.',
+    descriptionWithHandle: 'Save your Hive posting key so you can vote, comment and post directly as @{handle}.',
+    close: 'Close',
   },
   settings: {
     title: '⚙️ Settings',

--- a/lib/i18n/locales/es.ts
+++ b/lib/i18n/locales/es.ts
@@ -469,6 +469,14 @@ export const es = {
     helpSkateHiveDetailed: 'Ayuda a SkateHive votando la publicación principal del contenedor de snaps donde se almacenan todos los snaps.',
     container: 'Contenedor',
     upvoteNow: 'Votar Ahora',
+    needsPostingKey: 'Agrega tu clave de posting de Hive para votar.',
+    addPostingKey: 'Agregar clave de posting',
+  },
+  postingKeyDialog: {
+    title: 'Agrega tu clave de posting de Hive',
+    description: 'Guarda tu clave de posting de Hive para votar, comentar y publicar directamente con tu cuenta de Hive.',
+    descriptionWithHandle: 'Guarda tu clave de posting de Hive para votar, comentar y publicar directamente como @{handle}.',
+    close: 'Cerrar',
   },
   settings: {
     title: '⚙️ Configuración',

--- a/lib/i18n/locales/lg.ts
+++ b/lib/i18n/locales/lg.ts
@@ -468,6 +468,14 @@ export const lg = {
     helpSkateHiveDetailed: 'Tusobola SkateHive okuweta snap container post gwe snaps zonna ziggala.',
     container: 'Container',
     upvoteNow: 'Weta Kakaati',
+    needsPostingKey: 'Yongerako posting key yo eya Hive okusobola okuweta.',
+    addPostingKey: 'Yongerako posting key',
+  },
+  postingKeyDialog: {
+    title: 'Yongerako posting key yo eya Hive',
+    description: 'Tereka posting key yo eya Hive osobole okuweta, okuwandiika n’okuposta ku akawunti yo eya Hive.',
+    descriptionWithHandle: 'Tereka posting key yo eya Hive osobole okuweta, okuwandiika n’okuposta nga @{handle}.',
+    close: 'Ggalawo',
   },
   settings: {
     title: '⚙️ Setinga',

--- a/lib/i18n/locales/pt-BR.ts
+++ b/lib/i18n/locales/pt-BR.ts
@@ -469,6 +469,14 @@ export const ptBR = {
     helpSkateHiveDetailed: 'Ajude o SkateHive votando no post principal do container de snaps onde todos os snaps são armazenados.',
     container: 'Container',
     upvoteNow: 'Votar Agora',
+    needsPostingKey: 'Adicione sua chave POST do Hive para votar.',
+    addPostingKey: 'Adicionar chave POST',
+  },
+  postingKeyDialog: {
+    title: 'Adicione sua chave POST do Hive',
+    description: 'Salve sua chave POST do Hive para votar, comentar e postar diretamente na sua conta Hive.',
+    descriptionWithHandle: 'Salve sua chave POST do Hive para votar, comentar e postar diretamente como @{handle}.',
+    close: 'Fechar',
   },
   settings: {
     title: '⚙️ Configurações',

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -369,6 +369,14 @@ export interface TranslationSchema {
     helpSkateHiveDetailed: string;
     container: string;
     upvoteNow: string;
+    needsPostingKey: string;
+    addPostingKey: string;
+  };
+  postingKeyDialog: {
+    title: string;
+    description: string;
+    descriptionWithHandle: string;
+    close: string;
   };
   settings: {
     title: string;


### PR DESCRIPTION
## Summary
- Closes #104.
- When an email-logged user tries to upvote without a stored Hive posting key, the same posting-key panel from `/settings` (via [UserbasePostingKeyPanel](components/userbase/UserbasePostingKeyPanel.tsx)) now auto-opens as a modal from the vote-failure flow, instead of leaving the user stuck on a "Failed to vote" toast.
- Introduces a small global [PostingKeyDialogContext](contexts/PostingKeyDialogContext.tsx) + [PostingKeyDialog](components/userbase/PostingKeyDialog.tsx) wrapper so any future flow (comments, posts) can trigger the same dialog without re-implementing the UI.
- [useHiveVote](hooks/useHiveVote.ts) detects the existing `POSTING_KEY_NOT_STORED` API response, opens the dialog (passing the linked Hive handle when available so the copy reads "publish as @handle"), and throws a friendlier i18n'd error so consumers' existing failure toasts still render.

## Why this approach
- The hook is the single point that already detects `POSTING_KEY_NOT_STORED` — handling it there means every vote surface (homepage feed, mobile, blog, bounties, share menu, etc.) gets the dialog without touching 7+ call sites.
- Reuses `UserbasePostingKeyPanel` verbatim, so the save endpoint (`POST /api/userbase/keys/posting`), validation, and Hive-identity gating stay identical to Settings.
- After the user saves their key, the next vote succeeds automatically because the API will now find their stored key — no retry plumbing needed in 7 different components.

## Acceptance criteria check
- [x] Email-logged user without posting key can tap vote → dialog opens from the failure flow.
- [x] Key is saved via the same backend path as Settings (`UserbasePostingKeyPanel` reused unchanged).
- [x] Existing wallet-connected (Keychain/Aioha) voting path is untouched.
- [x] All new visible strings live in [lib/i18n/locales](lib/i18n/locales/) across `en`, `pt-BR`, `es`, `lg` with matching schema in [types.ts](lib/i18n/types.ts).
- [x] No hardcoded colors — dialog uses `SkateModal` + theme tokens (`text`, etc).

## Test plan
- [ ] Sign in with email-only account (no linked Hive, no stored posting key) → tap upvote on any snap → confirm dialog opens with "Add your Hive posting key" title.
- [ ] Repeat with email account that has a linked Hive identity → confirm the dialog description shows "...directly as @handle".
- [ ] Save a valid posting key inside the dialog → confirm success toast, dialog stays open so user can close it, then tap upvote again → vote succeeds.
- [ ] Sign in with Hive Keychain → confirm voting still works unchanged and no dialog appears.
- [ ] Switch locale to `pt-BR`/`es`/`lg` → confirm dialog strings are translated.
- [ ] Run `pnpm type-check` → green (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a posting key dialog that prompts users to add their Hive posting key when attempting to vote without one stored.
  * Dialog displays personalized messages based on user handle when provided.

* **Localization**
  * Extended language support with new translations for posting key authentication prompts and dialog in English, Spanish, Luganda, and Portuguese (Brazil).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SkateHive/skatehive3.0/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->