### PR TITLE
feat(snap-composer): Farcaster cross-posting for snaps

### DIFF
--- a/app/api/farcaster/cast/route.ts
+++ b/app/api/farcaster/cast/route.ts
@@ -62,11 +62,19 @@ async function getSignerUuid(request: NextRequest) {
   return { signerUuid };
 }
 
+// Allowed Farcaster channels for cross-posts. Restricting server-side
+// prevents typos / abuse and matches the UI options surfaced to users.
+const ALLOWED_CHANNELS = new Set(["skateboard", "gnars", "higher"]);
+
 /**
  * POST /api/farcaster/cast
  * Publish a root Farcaster cast (no parent) on behalf of the authenticated user.
  *
- * Body: { text: string, embeds?: ({ url: string } | { cast_id: { fid, hash } })[] }
+ * Body: {
+ *   text: string,
+ *   embeds?: ({ url: string } | { cast_id: { fid, hash } })[],
+ *   channel_id?: string,
+ * }
  */
 export async function POST(request: NextRequest) {
   const signer = await getSignerUuid(request);
@@ -108,7 +116,27 @@ export async function POST(request: NextRequest) {
       .slice(0, 2);
   }
 
-  const result = await publishCast(signer.signerUuid!, text.trim(), undefined, embeds);
+  let channelId: string | undefined;
+  if (body?.channel_id) {
+    const raw = String(body.channel_id).trim().toLowerCase().replace(/^\/+/, "");
+    if (raw) {
+      if (!ALLOWED_CHANNELS.has(raw)) {
+        return NextResponse.json(
+          { error: `Channel /${raw} is not enabled for cross-posting` },
+          { status: 400 }
+        );
+      }
+      channelId = raw;
+    }
+  }
+
+  const result = await publishCast(
+    signer.signerUuid!,
+    text.trim(),
+    undefined,
+    embeds,
+    channelId
+  );
   if (!result.success) {
     return NextResponse.json({ error: result.error }, { status: 500 });
   }

--- a/app/api/farcaster/cast/route.ts
+++ b/app/api/farcaster/cast/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import crypto from "crypto";
+import { publishCast, type CastEmbed } from "@/lib/farcaster/neynar";
+
+const supabaseUrl =
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+const supabase =
+  supabaseUrl && supabaseServiceKey
+    ? createClient(supabaseUrl, supabaseServiceKey, {
+        auth: { autoRefreshToken: false, persistSession: false },
+      })
+    : null;
+
+function hashToken(token: string) {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+async function getSignerUuid(request: NextRequest) {
+  if (!supabase) {
+    return { error: NextResponse.json({ error: "Missing config" }, { status: 500 }) };
+  }
+
+  const refreshToken = request.cookies.get("userbase_refresh")?.value;
+  if (!refreshToken) {
+    return { error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }) };
+  }
+
+  const { data: sessionRows } = await supabase
+    .from("userbase_sessions")
+    .select("user_id, expires_at, revoked_at")
+    .eq("refresh_token_hash", hashToken(refreshToken))
+    .is("revoked_at", null)
+    .limit(1);
+
+  const session = sessionRows?.[0];
+  if (!session || new Date(session.expires_at) < new Date()) {
+    return { error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }) };
+  }
+
+  const { data: identities } = await supabase
+    .from("userbase_identities")
+    .select("metadata")
+    .eq("user_id", session.user_id)
+    .eq("type", "farcaster")
+    .limit(1);
+
+  const metadata = identities?.[0]?.metadata as Record<string, unknown> | undefined;
+  const signerUuid = metadata?.signer_uuid as string | undefined;
+
+  if (!signerUuid || metadata?.signer_status !== "approved") {
+    return {
+      error: NextResponse.json(
+        { error: "Farcaster signer not approved", needsSigner: true },
+        { status: 403 }
+      ),
+    };
+  }
+
+  return { signerUuid };
+}
+
+/**
+ * POST /api/farcaster/cast
+ * Publish a root Farcaster cast (no parent) on behalf of the authenticated user.
+ *
+ * Body: { text: string, embeds?: ({ url: string } | { cast_id: { fid, hash } })[] }
+ */
+export async function POST(request: NextRequest) {
+  const signer = await getSignerUuid(request);
+  if (signer.error) return signer.error;
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const text: unknown = body?.text;
+  if (!text || typeof text !== "string" || !text.trim()) {
+    return NextResponse.json({ error: "Missing text" }, { status: 400 });
+  }
+  if (text.length > 1024) {
+    return NextResponse.json(
+      { error: "Text too long (max 1024 chars)" },
+      { status: 400 }
+    );
+  }
+
+  let embeds: CastEmbed[] | undefined;
+  if (Array.isArray(body?.embeds)) {
+    embeds = body.embeds
+      .filter((e: any) => {
+        if (e && typeof e === "object" && typeof e.url === "string") return true;
+        if (
+          e &&
+          typeof e === "object" &&
+          e.cast_id &&
+          typeof e.cast_id.fid === "number" &&
+          typeof e.cast_id.hash === "string"
+        )
+          return true;
+        return false;
+      })
+      .slice(0, 2);
+  }
+
+  const result = await publishCast(signer.signerUuid!, text.trim(), undefined, embeds);
+  if (!result.success) {
+    return NextResponse.json({ error: result.error }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true, hash: result.hash });
+}

--- a/components/blog/PostDetails.tsx
+++ b/components/blog/PostDetails.tsx
@@ -262,11 +262,7 @@ export default function PostDetails({
     prevPayoutValueRef.current = currentPayout;
   }, [payoutValue, triggerUpvoteStoke]);
 
-  // Check if current user is the author
-  const isAuthor =
-    walletUser && walletUser.toLowerCase() === author.toLowerCase();
-
-  // Use the post edit hook
+  // Use the post edit hook (handles Keychain + stored-posting-key paths)
   const {
     isEditing,
     editedContent,
@@ -280,7 +276,12 @@ export default function PostDetails({
     showUpgradeModal,
     upgradeAction,
     closeUpgradeModal,
+    canEditThisPost,
   } = usePostEdit(post);
+
+  // Edit-button visibility: any user whose effective Hive identity matches
+  // the post's author, whether they're on Keychain or using a stored key.
+  const isAuthor = canEditThisPost;
 
   const {
     hivePower,

--- a/components/homepage/Snap.tsx
+++ b/components/homepage/Snap.tsx
@@ -117,6 +117,7 @@ const Snap = React.memo(function Snap({
     handleEditClick,
     handleCancelEdit,
     handleSaveEdit,
+    canEditThisPost,
   } = usePostEdit(discussion);
 
   const [isDeleted, setIsDeleted] = useState(false);
@@ -379,7 +380,7 @@ const Snap = React.memo(function Snap({
               color={"primary"}
             />
             <MenuList bg={"background"} color={"primary"}>
-              {walletUser === discussion.author && (
+              {canEditThisPost && (
                 <MenuItem
                   onClick={handleEditClick}
                   bg={"background"}

--- a/components/homepage/SnapComposer.tsx
+++ b/components/homepage/SnapComposer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useRef, useMemo, useCallback, useEffect } from "react";
+import React, { useState, useRef, useMemo, useCallback } from "react";
 import dynamic from "next/dynamic";
 import { useTranslations } from "@/contexts/LocaleContext";
 import { useSkateDialog } from "@/hooks/useSkateDialog";
@@ -144,16 +144,14 @@ const SnapComposer = React.memo(function SnapComposer({
     if (!fid || !username) return null;
     return { fid, username };
   }, [farcasterIdentity, farcasterProfile]);
-  const farcasterAvailable = farcasterEligible && farcasterSignerApproved;
-  // Default: post to every platform the user has linked & authorized.
+  // Default: opt-in to every linked platform. DestinationMenu filters the
+  // rendered checkboxes by actual eligibility (e.g. won't surface
+  // Farcaster as checked if the signer isn't approved), and handleComment
+  // re-checks `farcasterLinkage` before firing the cast — so defaulting
+  // these to true is safe even when Farcaster isn't actually usable.
   const [postToHive, setPostToHive] = useState(true);
-  const [postToFarcaster, setPostToFarcaster] = useState(false);
+  const [postToFarcaster, setPostToFarcaster] = useState(true);
   const [farcasterChannel, setFarcasterChannel] = useState<string | null>(null);
-  // Re-sync the default whenever eligibility changes (e.g. user just approved
-  // a signer in another tab).
-  useEffect(() => {
-    setPostToFarcaster(farcasterAvailable);
-  }, [farcasterAvailable]);
   const toast = useToast();
   const t = useTranslations();
   const { prompt, SkateDialogComponent } = useSkateDialog();

--- a/components/homepage/SnapComposer.tsx
+++ b/components/homepage/SnapComposer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useRef, useMemo, useCallback } from "react";
+import React, { useState, useRef, useMemo, useCallback, useEffect } from "react";
 import dynamic from "next/dynamic";
 import { useTranslations } from "@/contexts/LocaleContext";
 import { useSkateDialog } from "@/hooks/useSkateDialog";
@@ -19,10 +19,14 @@ import {
   Switch,
   Text,
   Icon,
-  Link as ChakraLink,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuOptionGroup,
+  MenuItemOption,
   useToast,
 } from "@chakra-ui/react";
-import NextLink from "next/link";
+import { ChevronDownIcon } from "@chakra-ui/icons";
 import { SiFarcaster } from "react-icons/si";
 import { useAioha } from "@aioha/react-ui";
 import useEffectiveHiveUser from "@/hooks/useEffectiveHiveUser";
@@ -69,8 +73,6 @@ import { TbGif } from "react-icons/tb";
 import MatrixOverlay from "@/components/graphics/MatrixOverlay";
 import { useLinkedIdentities } from "@/contexts/LinkedIdentityContext";
 import { useFarcasterSession } from "@/hooks/useFarcasterSession";
-
-type FarcasterDestination = "skatehive" | "farcaster" | "both";
 
 const CAST_MAX_CHARS = 1024;
 
@@ -132,8 +134,15 @@ const SnapComposer = React.memo(function SnapComposer({
     if (!fid || !username) return null;
     return { fid, username };
   }, [farcasterIdentity, farcasterProfile]);
-  const [farcasterDestination, setFarcasterDestination] =
-    useState<FarcasterDestination>("skatehive");
+  const farcasterAvailable = farcasterEligible && farcasterSignerApproved;
+  // Default: post to every platform the user has linked & authorized.
+  const [postToHive, setPostToHive] = useState(true);
+  const [postToFarcaster, setPostToFarcaster] = useState(false);
+  // Re-sync the default whenever eligibility changes (e.g. user just approved
+  // a signer in another tab).
+  useEffect(() => {
+    setPostToFarcaster(farcasterAvailable);
+  }, [farcasterAvailable]);
   const toast = useToast();
   const t = useTranslations();
   const { prompt, SkateDialogComponent } = useSkateDialog();
@@ -641,10 +650,18 @@ const SnapComposer = React.memo(function SnapComposer({
       return;
     }
 
-    const wantsSkatehive =
-      farcasterDestination === "skatehive" || farcasterDestination === "both";
-    const wantsFarcaster =
-      farcasterDestination === "farcaster" || farcasterDestination === "both";
+    const wantsSkatehive = postToHive;
+    const wantsFarcaster = postToFarcaster;
+
+    if (!wantsSkatehive && !wantsFarcaster) {
+      toast({
+        title: "Pick at least one destination",
+        status: "warning",
+        duration: 3000,
+        isClosable: true,
+      });
+      return;
+    }
 
     // Farcaster-only: skip Hive entirely, publish a cast directly.
     if (!wantsSkatehive && wantsFarcaster) {
@@ -1028,7 +1045,8 @@ const SnapComposer = React.memo(function SnapComposer({
     linkedHiveHandle,
     instagramCrossPost,
     isMainFeedSnap,
-    farcasterDestination,
+    postToHive,
+    postToFarcaster,
     farcasterEligible,
     farcasterLinkage,
   ]);
@@ -1455,58 +1473,6 @@ const SnapComposer = React.memo(function SnapComposer({
             </HStack>
           )}
 
-          {/* Farcaster destination — only if user has a linked Farcaster identity */}
-          {farcasterEligible && (
-            <HStack justify="flex-end" align="center" spacing={2} mb={2} flexWrap="wrap">
-              <Icon as={SiFarcaster} color="primary" boxSize={3.5} />
-              <Text fontSize="xs" color="dim" fontFamily="mono">
-                {farcasterLinkage ? `@${farcasterLinkage.username}` : "Farcaster"}
-              </Text>
-              <ButtonGroup size="xs" isAttached variant="outline">
-                <DestinationPill
-                  active={farcasterDestination === "skatehive"}
-                  onClick={() => setFarcasterDestination("skatehive")}
-                  label="SkateHive"
-                  disabled={isLoading}
-                />
-                <DestinationPill
-                  active={farcasterDestination === "farcaster"}
-                  onClick={() => setFarcasterDestination("farcaster")}
-                  label="Farcaster"
-                  disabled={isLoading || !farcasterSignerApproved}
-                  disabledHint={
-                    !farcasterSignerApproved
-                      ? "Authorize Farcaster posting in Settings first"
-                      : undefined
-                  }
-                />
-                <DestinationPill
-                  active={farcasterDestination === "both"}
-                  onClick={() => setFarcasterDestination("both")}
-                  label="Both"
-                  disabled={isLoading || !farcasterSignerApproved}
-                  disabledHint={
-                    !farcasterSignerApproved
-                      ? "Authorize Farcaster posting in Settings first"
-                      : undefined
-                  }
-                />
-              </ButtonGroup>
-              {!farcasterSignerApproved && (
-                <ChakraLink
-                  as={NextLink}
-                  href="/settings"
-                  fontSize="xs"
-                  fontFamily="mono"
-                  color="primary"
-                  _hover={{ textDecoration: "underline" }}
-                >
-                  Authorize →
-                </ChakraLink>
-              )}
-            </HStack>
-          )}
-
           {/* Instagram cross-post toggle — only for main-feed snaps */}
           {isMainFeedSnap && (
             <HStack
@@ -1693,32 +1659,45 @@ const SnapComposer = React.memo(function SnapComposer({
               </Tooltip>
             </HStack>
             <Box display={buttonSize === "sm" ? "inline-block" : undefined}>
-              <Button
-                id="snap-composer-submit-btn"
-                data-testid="snap-composer-submit"
-                bg="primary"
-                color="background"
-                _hover={{ bg: "muted", color: "text", border: "tb1" }}
-                isLoading={isLoading}
-                isDisabled={isLoading || isUploadingMedia}
-                onClick={handleComment}
-                borderRadius={"none"}
-                fontWeight="bold"
-                px={buttonSize === "sm" ? 1 : 8}
-                mt={2}
-                mb={1}
-                minWidth={buttonSize === "sm" ? undefined : "120px"}
-                width={buttonSize === "sm" ? undefined : "30%"}
-                maxWidth={buttonSize === "sm" ? undefined : undefined}
-                fontSize={buttonSize === "sm" ? "xs" : "lg"}
-                lineHeight={buttonSize === "sm" ? "1" : undefined}
-                flex={buttonSize === "sm" ? "none" : undefined}
-                alignSelf={buttonSize === "sm" ? "flex-start" : undefined}
-                display={buttonSize === "sm" ? "inline-flex" : undefined}
-                maxH={"2rem"}
-              >
-                {buttonText}
-              </Button>
+              <ButtonGroup isAttached>
+                <Button
+                  id="snap-composer-submit-btn"
+                  data-testid="snap-composer-submit"
+                  bg="primary"
+                  color="background"
+                  _hover={{ bg: "muted", color: "text", border: "tb1" }}
+                  isLoading={isLoading}
+                  isDisabled={isLoading || isUploadingMedia || (!postToHive && !postToFarcaster)}
+                  onClick={handleComment}
+                  borderRadius={"none"}
+                  fontWeight="bold"
+                  px={buttonSize === "sm" ? 1 : 8}
+                  mt={2}
+                  mb={1}
+                  minWidth={buttonSize === "sm" ? undefined : "120px"}
+                  width={buttonSize === "sm" ? undefined : undefined}
+                  fontSize={buttonSize === "sm" ? "xs" : "lg"}
+                  lineHeight={buttonSize === "sm" ? "1" : undefined}
+                  flex={buttonSize === "sm" ? "none" : undefined}
+                  alignSelf={buttonSize === "sm" ? "flex-start" : undefined}
+                  display={buttonSize === "sm" ? "inline-flex" : undefined}
+                  maxH={"2rem"}
+                >
+                  {buttonText}
+                </Button>
+                {farcasterEligible && (
+                  <DestinationMenu
+                    postToHive={postToHive}
+                    postToFarcaster={postToFarcaster}
+                    setPostToHive={setPostToHive}
+                    setPostToFarcaster={setPostToFarcaster}
+                    farcasterSignerApproved={farcasterSignerApproved}
+                    farcasterUsername={farcasterLinkage?.username || null}
+                    isLoading={isLoading}
+                    buttonSize={buttonSize}
+                  />
+                )}
+              </ButtonGroup>
             </Box>
           </HStack>
           <Box width="100%">
@@ -1808,49 +1787,104 @@ const SnapComposer = React.memo(function SnapComposer({
 
 export default SnapComposer;
 
-function DestinationPill({
-  active,
-  onClick,
-  label,
-  disabled,
-  disabledHint,
+function DestinationMenu({
+  postToHive,
+  postToFarcaster,
+  setPostToHive,
+  setPostToFarcaster,
+  farcasterSignerApproved,
+  farcasterUsername,
+  isLoading,
+  buttonSize,
 }: {
-  active: boolean;
-  onClick: () => void;
-  label: string;
-  disabled?: boolean;
-  disabledHint?: string;
+  postToHive: boolean;
+  postToFarcaster: boolean;
+  setPostToHive: (v: boolean) => void;
+  setPostToFarcaster: (v: boolean) => void;
+  farcasterSignerApproved: boolean;
+  farcasterUsername: string | null;
+  isLoading: boolean;
+  buttonSize: "sm" | "md" | "lg";
 }) {
-  const btn = (
-    <Button
-      onClick={disabled ? undefined : onClick}
-      isDisabled={disabled}
-      bg={active ? "primary" : "transparent"}
-      color={active ? "background" : "dim"}
-      borderColor={active ? "primary" : "border"}
-      borderWidth="1px"
-      fontFamily="mono"
-      fontSize="2xs"
-      fontWeight={active ? "bold" : "medium"}
-      _hover={
-        disabled
-          ? {}
-          : active
-          ? { bg: "accent" }
-          : { bg: "subtle", color: "text" }
-      }
-      _disabled={{ opacity: 0.4, cursor: "not-allowed" }}
-      px={3}
-      h="24px"
-    >
-      {label}
-    </Button>
-  );
-  return disabled && disabledHint ? (
-    <Tooltip label={disabledHint} hasArrow placement="top">
-      <Box>{btn}</Box>
-    </Tooltip>
-  ) : (
-    btn
+  const selected: string[] = [];
+  if (postToHive) selected.push("hive");
+  if (postToFarcaster) selected.push("farcaster");
+
+  return (
+    <Menu placement="top-end" closeOnSelect={false}>
+      <MenuButton
+        as={IconButton}
+        aria-label="Choose destinations"
+        icon={<ChevronDownIcon boxSize={5} />}
+        bg="primary"
+        color="background"
+        borderRadius="none"
+        borderLeft="1px solid"
+        borderColor="background"
+        _hover={{ bg: "muted", color: "text" }}
+        _active={{ bg: "muted" }}
+        isDisabled={isLoading}
+        mt={2}
+        mb={1}
+        maxH="2rem"
+        minW="32px"
+        h={buttonSize === "sm" ? undefined : undefined}
+      />
+      <MenuList bg="background" borderColor="primary" minW="220px">
+        <MenuOptionGroup
+          type="checkbox"
+          value={selected}
+          onChange={(values) => {
+            const next = Array.isArray(values) ? values : [values];
+            setPostToHive(next.includes("hive"));
+            setPostToFarcaster(next.includes("farcaster"));
+          }}
+          title="Post to"
+          fontSize="xs"
+          fontFamily="mono"
+          color="dim"
+        >
+          <MenuItemOption value="hive" bg="background" _hover={{ bg: "subtle" }}>
+            <HStack spacing={2}>
+              <Image
+                src="/logos/SKATE_HIVE_CIRCLE.svg"
+                alt="SkateHive"
+                boxSize="16px"
+              />
+              <Text fontFamily="mono" fontSize="sm" color="text">
+                SkateHive
+              </Text>
+            </HStack>
+          </MenuItemOption>
+          <Tooltip
+            label="Authorize Farcaster posting in Settings first"
+            isDisabled={farcasterSignerApproved}
+            hasArrow
+            placement="left"
+          >
+            <Box>
+              <MenuItemOption
+                value="farcaster"
+                isDisabled={!farcasterSignerApproved}
+                bg="background"
+                _hover={{ bg: "subtle" }}
+              >
+                <HStack spacing={2}>
+                  <Icon as={SiFarcaster} color="primary" boxSize={4} />
+                  <Text fontFamily="mono" fontSize="sm" color="text">
+                    Farcaster
+                    {farcasterUsername && (
+                      <Text as="span" color="dim" fontSize="xs" ml={1}>
+                        @{farcasterUsername}
+                      </Text>
+                    )}
+                  </Text>
+                </HStack>
+              </MenuItemOption>
+            </Box>
+          </Tooltip>
+        </MenuOptionGroup>
+      </MenuList>
+    </Menu>
   );
 }

--- a/components/homepage/SnapComposer.tsx
+++ b/components/homepage/SnapComposer.tsx
@@ -78,6 +78,14 @@ import { useFarcasterSession } from "@/hooks/useFarcasterSession";
 
 const CAST_MAX_CHARS = 1024;
 
+// Channels enabled for Farcaster cross-posting. Mirrors the server-side
+// whitelist in /api/farcaster/cast/route.ts — keep them in sync.
+const FARCASTER_CHANNELS = [
+  { id: "skateboard", label: "/skateboard" },
+  { id: "gnars", label: "/gnars" },
+  { id: "higher", label: "/higher" },
+] as const;
+
 function buildSnapCastText(body: string, url: string | null): string {
     const clean = body.trim();
     if (!url) {
@@ -140,6 +148,7 @@ const SnapComposer = React.memo(function SnapComposer({
   // Default: post to every platform the user has linked & authorized.
   const [postToHive, setPostToHive] = useState(true);
   const [postToFarcaster, setPostToFarcaster] = useState(false);
+  const [farcasterChannel, setFarcasterChannel] = useState<string | null>(null);
   // Re-sync the default whenever eligibility changes (e.g. user just approved
   // a signer in another tab).
   useEffect(() => {
@@ -678,13 +687,18 @@ const SnapComposer = React.memo(function SnapComposer({
       }
       setIsLoading(true);
       try {
-        const firstImage = compressedImages[0]?.url || null;
         const castText = buildSnapCastText(commentBody, APP_CONFIG.ORIGIN);
-        const embeds = firstImage ? [{ url: firstImage }] : undefined;
+        const embeds = compressedImages
+          .slice(0, 2)
+          .map((img) => ({ url: img.url }));
         const res = await fetch("/api/farcaster/cast", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ text: castText, embeds }),
+          body: JSON.stringify({
+            text: castText,
+            embeds: embeds.length > 0 ? embeds : undefined,
+            channel_id: farcasterChannel || undefined,
+          }),
         });
         const data = await res.json().catch(() => ({}));
         if (!res.ok) {
@@ -907,12 +921,22 @@ const SnapComposer = React.memo(function SnapComposer({
           if (wantsFarcaster && farcasterLinkage) {
             const snapUrl = `${APP_CONFIG.ORIGIN.replace(/\/$/, "")}/user/${commentAuthor}/snap/${permlink}`;
             const castText = buildSnapCastText(commentBody, snapUrl);
+            // Image snaps: embed the image(s) directly so Warpcast shows them
+            // as visual previews instead of rendering the SkateHive frame
+            // (which falls back to the profile card). Video/text-only snaps
+            // embed the snap URL so the frame can render the video thumbnail.
+            const imageEmbeds = compressedImages
+              .slice(0, 2)
+              .map((img) => ({ url: img.url }));
+            const embeds =
+              imageEmbeds.length > 0 ? imageEmbeds : [{ url: snapUrl }];
             fetch("/api/farcaster/cast", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({
                 text: castText,
-                embeds: [{ url: snapUrl }],
+                embeds,
+                channel_id: farcasterChannel || undefined,
               }),
             })
               .then(async (res) => {
@@ -1049,6 +1073,7 @@ const SnapComposer = React.memo(function SnapComposer({
     isMainFeedSnap,
     postToHive,
     postToFarcaster,
+    farcasterChannel,
     farcasterEligible,
     farcasterLinkage,
   ]);
@@ -1692,6 +1717,8 @@ const SnapComposer = React.memo(function SnapComposer({
                   postToFarcaster={postToFarcaster}
                   setPostToHive={setPostToHive}
                   setPostToFarcaster={setPostToFarcaster}
+                  farcasterChannel={farcasterChannel}
+                  setFarcasterChannel={setFarcasterChannel}
                   farcasterEligible={farcasterEligible}
                   farcasterSignerApproved={farcasterSignerApproved}
                   farcasterUsername={farcasterLinkage?.username || null}
@@ -1793,6 +1820,8 @@ function DestinationMenu({
   postToFarcaster,
   setPostToHive,
   setPostToFarcaster,
+  farcasterChannel,
+  setFarcasterChannel,
   farcasterEligible,
   farcasterSignerApproved,
   farcasterUsername,
@@ -1803,6 +1832,8 @@ function DestinationMenu({
   postToFarcaster: boolean;
   setPostToHive: (v: boolean) => void;
   setPostToFarcaster: (v: boolean) => void;
+  farcasterChannel: string | null;
+  setFarcasterChannel: (v: string | null) => void;
   farcasterEligible: boolean;
   farcasterSignerApproved: boolean;
   farcasterUsername: string | null;
@@ -1909,6 +1940,43 @@ function DestinationMenu({
             </Box>
           </Tooltip>
         </MenuOptionGroup>
+
+        {/* Channel selector — only meaningful when Farcaster is checked. */}
+        {postToFarcaster && farcasterUsable && (
+          <MenuOptionGroup
+            type="radio"
+            value={farcasterChannel ?? "__none__"}
+            onChange={(value) => {
+              const v = Array.isArray(value) ? value[0] : value;
+              setFarcasterChannel(v === "__none__" ? null : v);
+            }}
+            title="Farcaster channel"
+            fontSize="xs"
+            fontFamily="mono"
+            color="dim"
+          >
+            <MenuItemOption value="__none__" bg="background" _hover={{ bg: "subtle" }}>
+              <Text fontFamily="mono" fontSize="sm" color="text">
+                no channel
+                <Text as="span" color="dim" fontSize="xs" ml={1}>
+                  (your feed)
+                </Text>
+              </Text>
+            </MenuItemOption>
+            {FARCASTER_CHANNELS.map((ch) => (
+              <MenuItemOption
+                key={ch.id}
+                value={ch.id}
+                bg="background"
+                _hover={{ bg: "subtle" }}
+              >
+                <Text fontFamily="mono" fontSize="sm" color="text">
+                  {ch.label}
+                </Text>
+              </MenuItemOption>
+            ))}
+          </MenuOptionGroup>
+        )}
       </MenuList>
     </Menu>
   );

--- a/components/homepage/SnapComposer.tsx
+++ b/components/homepage/SnapComposer.tsx
@@ -24,8 +24,10 @@ import {
   MenuList,
   MenuOptionGroup,
   MenuItemOption,
+  Link as ChakraLink,
   useToast,
 } from "@chakra-ui/react";
+import NextLink from "next/link";
 import { ChevronDownIcon } from "@chakra-ui/icons";
 import { SiFarcaster } from "react-icons/si";
 import { useAioha } from "@aioha/react-ui";
@@ -1685,18 +1687,17 @@ const SnapComposer = React.memo(function SnapComposer({
                 >
                   {buttonText}
                 </Button>
-                {farcasterEligible && (
-                  <DestinationMenu
-                    postToHive={postToHive}
-                    postToFarcaster={postToFarcaster}
-                    setPostToHive={setPostToHive}
-                    setPostToFarcaster={setPostToFarcaster}
-                    farcasterSignerApproved={farcasterSignerApproved}
-                    farcasterUsername={farcasterLinkage?.username || null}
-                    isLoading={isLoading}
-                    buttonSize={buttonSize}
-                  />
-                )}
+                <DestinationMenu
+                  postToHive={postToHive}
+                  postToFarcaster={postToFarcaster}
+                  setPostToHive={setPostToHive}
+                  setPostToFarcaster={setPostToFarcaster}
+                  farcasterEligible={farcasterEligible}
+                  farcasterSignerApproved={farcasterSignerApproved}
+                  farcasterUsername={farcasterLinkage?.username || null}
+                  isLoading={isLoading}
+                  buttonSize={buttonSize}
+                />
               </ButtonGroup>
             </Box>
           </HStack>
@@ -1792,6 +1793,7 @@ function DestinationMenu({
   postToFarcaster,
   setPostToHive,
   setPostToFarcaster,
+  farcasterEligible,
   farcasterSignerApproved,
   farcasterUsername,
   isLoading,
@@ -1801,36 +1803,45 @@ function DestinationMenu({
   postToFarcaster: boolean;
   setPostToHive: (v: boolean) => void;
   setPostToFarcaster: (v: boolean) => void;
+  farcasterEligible: boolean;
   farcasterSignerApproved: boolean;
   farcasterUsername: string | null;
   isLoading: boolean;
   buttonSize: "sm" | "md" | "lg";
 }) {
+  const farcasterUsable = farcasterEligible && farcasterSignerApproved;
   const selected: string[] = [];
   if (postToHive) selected.push("hive");
-  if (postToFarcaster) selected.push("farcaster");
+  if (postToFarcaster && farcasterUsable) selected.push("farcaster");
+
+  const farcasterTooltip = !farcasterEligible
+    ? "Link your Farcaster account in Settings to enable cross-posting"
+    : !farcasterSignerApproved
+    ? "Authorize Farcaster posting in Settings first"
+    : "";
 
   return (
     <Menu placement="top-end" closeOnSelect={false}>
       <MenuButton
-        as={IconButton}
+        as={Button}
         aria-label="Choose destinations"
-        icon={<ChevronDownIcon boxSize={5} />}
         bg="primary"
         color="background"
         borderRadius="none"
         borderLeft="1px solid"
-        borderColor="background"
+        borderLeftColor="background"
         _hover={{ bg: "muted", color: "text" }}
         _active={{ bg: "muted" }}
         isDisabled={isLoading}
         mt={2}
         mb={1}
         maxH="2rem"
-        minW="32px"
-        h={buttonSize === "sm" ? undefined : undefined}
-      />
-      <MenuList bg="background" borderColor="primary" minW="220px">
+        minW="36px"
+        px={2}
+      >
+        <ChevronDownIcon boxSize={5} />
+      </MenuButton>
+      <MenuList bg="background" borderColor="primary" minW="240px">
         <MenuOptionGroup
           type="checkbox"
           value={selected}
@@ -1857,19 +1868,19 @@ function DestinationMenu({
             </HStack>
           </MenuItemOption>
           <Tooltip
-            label="Authorize Farcaster posting in Settings first"
-            isDisabled={farcasterSignerApproved}
+            label={farcasterTooltip}
+            isDisabled={!farcasterTooltip}
             hasArrow
             placement="left"
           >
             <Box>
               <MenuItemOption
                 value="farcaster"
-                isDisabled={!farcasterSignerApproved}
+                isDisabled={!farcasterUsable}
                 bg="background"
                 _hover={{ bg: "subtle" }}
               >
-                <HStack spacing={2}>
+                <HStack spacing={2} w="full">
                   <Icon as={SiFarcaster} color="primary" boxSize={4} />
                   <Text fontFamily="mono" fontSize="sm" color="text">
                     Farcaster
@@ -1879,6 +1890,20 @@ function DestinationMenu({
                       </Text>
                     )}
                   </Text>
+                  {!farcasterUsable && (
+                    <ChakraLink
+                      as={NextLink}
+                      href="/settings"
+                      fontSize="2xs"
+                      fontFamily="mono"
+                      color="primary"
+                      ml="auto"
+                      _hover={{ textDecoration: "underline" }}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {farcasterEligible ? "authorize" : "link"} →
+                    </ChakraLink>
+                  )}
                 </HStack>
               </MenuItemOption>
             </Box>

--- a/components/homepage/SnapComposer.tsx
+++ b/components/homepage/SnapComposer.tsx
@@ -9,14 +9,21 @@ import {
   Textarea,
   HStack,
   Button,
+  ButtonGroup,
   Image,
   IconButton,
   Wrap,
   Progress,
   Input,
   Tooltip,
+  Switch,
+  Text,
+  Icon,
+  Link as ChakraLink,
   useToast,
 } from "@chakra-ui/react";
+import NextLink from "next/link";
+import { SiFarcaster } from "react-icons/si";
 import { useAioha } from "@aioha/react-ui";
 import useEffectiveHiveUser from "@/hooks/useEffectiveHiveUser";
 import GiphySelector from "./GiphySelector";
@@ -61,6 +68,25 @@ import { useInstagramHealth } from "@/hooks/useInstagramHealth";
 import { TbGif } from "react-icons/tb";
 import MatrixOverlay from "@/components/graphics/MatrixOverlay";
 import { useLinkedIdentities } from "@/contexts/LinkedIdentityContext";
+import { useFarcasterSession } from "@/hooks/useFarcasterSession";
+
+type FarcasterDestination = "skatehive" | "farcaster" | "both";
+
+const CAST_MAX_CHARS = 1024;
+
+function buildSnapCastText(body: string, url: string | null): string {
+    const clean = body.trim();
+    if (!url) {
+        return clean.length > CAST_MAX_CHARS
+            ? clean.slice(0, CAST_MAX_CHARS - 1).trim() + "…"
+            : clean;
+    }
+    const urlLine = `\n\n${url}`;
+    const budget = CAST_MAX_CHARS - urlLine.length;
+    const trimmed =
+        clean.length > budget ? clean.slice(0, Math.max(0, budget - 1)).trim() + "…" : clean;
+    return trimmed + urlLine;
+}
 
 // Check for demo mode via localStorage
 const SHOW_ERROR_DEMO =
@@ -88,8 +114,26 @@ const SnapComposer = React.memo(function SnapComposer({
 }: SnapComposerProps) {
   const { user, aioha } = useAioha();
   const { handle: effectiveUser, canUseAppFeatures } = useEffectiveHiveUser();
-  const { hiveIdentity: userbaseHiveIdentity } = useLinkedIdentities();
+  const { hiveIdentity: userbaseHiveIdentity, connections } = useLinkedIdentities();
+  const { profile: farcasterProfile } = useFarcasterSession();
   const linkedHiveHandle = userbaseHiveIdentity?.handle || null;
+
+  // Farcaster cross-post eligibility: linked Farcaster identity on the
+  // userbase account. Signer approval gates the Farcaster/Both choices.
+  const farcasterIdentity = connections.farcaster.identities[0] || null;
+  const farcasterEligible = !!farcasterIdentity;
+  const farcasterSignerApproved =
+    (farcasterIdentity?.metadata as Record<string, unknown> | undefined)?.signer_status ===
+    "approved";
+  const farcasterLinkage = useMemo(() => {
+    const fidRaw = farcasterIdentity?.external_id;
+    const fid = fidRaw ? Number(fidRaw) : farcasterProfile?.fid;
+    const username = farcasterIdentity?.handle || farcasterProfile?.username || null;
+    if (!fid || !username) return null;
+    return { fid, username };
+  }, [farcasterIdentity, farcasterProfile]);
+  const [farcasterDestination, setFarcasterDestination] =
+    useState<FarcasterDestination>("skatehive");
   const toast = useToast();
   const t = useTranslations();
   const { prompt, SkateDialogComponent } = useSkateDialog();
@@ -115,8 +159,14 @@ const SnapComposer = React.memo(function SnapComposer({
   const gifMakerWithSelectorRef = useRef<GIFMakerWithSelectorRef>(null);
   const [isProcessingGif, setIsProcessingGif] = useState(false);
 
-  // Instagram modal state
+  // Instagram modal state (for importing IG content into a snap)
   const [isInstagramModalOpen, setInstagramModalOpen] = useState(false);
+
+  // Instagram cross-post (outbound) state. Only meaningful for main-feed snaps
+  // (parent permlink === THREADS.PERMLINK) with attached media.
+  const [instagramCrossPost, setInstagramCrossPost] = useState(false);
+  const isMainFeedSnap = pp === HIVE_CONFIG.THREADS.PERMLINK;
+  const hasCrossPostMedia = compressedImages.length > 0 || !!videoUrl;
 
   // Error demo panel state
   const [showErrorDemo, setShowErrorDemo] = useState(SHOW_ERROR_DEMO);
@@ -591,6 +641,79 @@ const SnapComposer = React.memo(function SnapComposer({
       return;
     }
 
+    const wantsSkatehive =
+      farcasterDestination === "skatehive" || farcasterDestination === "both";
+    const wantsFarcaster =
+      farcasterDestination === "farcaster" || farcasterDestination === "both";
+
+    // Farcaster-only: skip Hive entirely, publish a cast directly.
+    if (!wantsSkatehive && wantsFarcaster) {
+      if (!farcasterEligible || !farcasterLinkage) {
+        toast({
+          title: "Link your Farcaster account first.",
+          status: "error",
+          duration: 4000,
+          isClosable: true,
+        });
+        return;
+      }
+      setIsLoading(true);
+      try {
+        const firstImage = compressedImages[0]?.url || null;
+        const castText = buildSnapCastText(commentBody, APP_CONFIG.ORIGIN);
+        const embeds = firstImage ? [{ url: firstImage }] : undefined;
+        const res = await fetch("/api/farcaster/cast", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ text: castText, embeds }),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          if (data?.needsSigner) {
+            toast({
+              title: "Authorize Farcaster posting first",
+              description:
+                "Open Settings → Farcaster to approve the signer, then try again.",
+              status: "warning",
+              duration: 6000,
+              isClosable: true,
+            });
+          } else {
+            toast({
+              title: "Failed to post to Farcaster.",
+              description: data?.error || "Unknown error.",
+              status: "error",
+              duration: 5000,
+              isClosable: true,
+            });
+          }
+          return;
+        }
+        toast({
+          title: "Posted to Farcaster!",
+          status: "success",
+          duration: 3000,
+          isClosable: true,
+        });
+        postBodyRef.current!.value = "";
+        setCompressedImages([]);
+        setSelectedGif(null);
+        setVideoUrl(null);
+        onClose();
+      } catch (err: any) {
+        toast({
+          title: "Failed to post to Farcaster.",
+          description: err?.message || "Network error.",
+          status: "error",
+          duration: 5000,
+          isClosable: true,
+        });
+      } finally {
+        setIsLoading(false);
+      }
+      return;
+    }
+
     if (!canUseAppFeatures) {
       toast({
         title: t('compose.loginRequired'),
@@ -658,6 +781,18 @@ const SnapComposer = React.memo(function SnapComposer({
             "🎬 Video-only post detected, added thumbnails to metadata.thumbnail:",
             videoThumbnails
           );
+        }
+
+        // Cross-post linkage: store the Farcaster fid + username on the Hive
+        // snap so the connection is durable and queryable later. The cast
+        // hash isn't known yet (cast is fired after Hive succeeds).
+        if (wantsFarcaster && farcasterLinkage) {
+          metadata.crosspost = {
+            farcaster: {
+              fid: farcasterLinkage.fid,
+              username: farcasterLinkage.username,
+            },
+          };
         }
 
         // Build the final comment body with images and video appended
@@ -747,6 +882,119 @@ const SnapComposer = React.memo(function SnapComposer({
 
           onNewComment(newComment);
           onClose();
+
+          // Fire-and-forget Farcaster cross-post. Same pattern as Instagram:
+          // don't block the UI; a warning toast surfaces if it fails.
+          if (wantsFarcaster && farcasterLinkage) {
+            const snapUrl = `${APP_CONFIG.ORIGIN.replace(/\/$/, "")}/user/${commentAuthor}/snap/${permlink}`;
+            const castText = buildSnapCastText(commentBody, snapUrl);
+            fetch("/api/farcaster/cast", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                text: castText,
+                embeds: [{ url: snapUrl }],
+              }),
+            })
+              .then(async (res) => {
+                const data = await res.json().catch(() => ({}));
+                if (res.ok) {
+                  toast({
+                    title: "Cross-posted to Farcaster",
+                    status: "success",
+                    duration: 3000,
+                    isClosable: true,
+                  });
+                } else if (data?.needsSigner) {
+                  toast({
+                    title: "Snap posted, but Farcaster needs signer approval",
+                    description:
+                      "Approve the Farcaster signer in Settings to enable cross-posting.",
+                    status: "warning",
+                    duration: 7000,
+                    isClosable: true,
+                  });
+                } else {
+                  toast({
+                    title: "Snap posted, but Farcaster cross-post failed",
+                    description: data?.error || "Try again later.",
+                    status: "warning",
+                    duration: 6000,
+                    isClosable: true,
+                  });
+                }
+              })
+              .catch((err) => {
+                toast({
+                  title: "Snap posted, but Farcaster cross-post failed",
+                  description: err?.message || "Network error.",
+                  status: "warning",
+                  duration: 6000,
+                  isClosable: true,
+                });
+              });
+          }
+
+          // Fire-and-forget Instagram cross-post. We deliberately don't await:
+          // Reels can take 30s+ to process and we don't want to block the UI.
+          // Toasts surface result/failure even after the composer modal closes.
+          if (
+            instagramCrossPost &&
+            isMainFeedSnap &&
+            (compressedImages[0]?.url || videoUrl)
+          ) {
+            const igPermalinkUrl = `${APP_CONFIG.ORIGIN.replace(/\/$/, "")}/user/${commentAuthor}/snap/${permlink}`;
+            const igImageUrl = compressedImages[0]?.url || null;
+            const igVideoUrl = videoUrl || null;
+            toast({
+              title: "Cross-posting to Instagram...",
+              status: "info",
+              duration: 4000,
+              isClosable: true,
+            });
+            fetch("/api/instagram/post", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                hive_author: commentAuthor,
+                hive_permlink: permlink,
+                body: finalCommentBody,
+                tags: snapsTags,
+                image_url: igImageUrl,
+                video_url: igVideoUrl,
+                permalink_url: igPermalinkUrl,
+              }),
+            })
+              .then(async (res) => {
+                const data = await res.json().catch(() => ({}));
+                if (res.ok) {
+                  toast({
+                    title: "Posted to @skatehive on Instagram",
+                    description: data?.ig_permalink || undefined,
+                    status: "success",
+                    duration: 4000,
+                    isClosable: true,
+                  });
+                } else {
+                  toast({
+                    title: "Instagram cross-post failed",
+                    description: data?.error || "Try again later.",
+                    status: "warning",
+                    duration: 6000,
+                    isClosable: true,
+                  });
+                }
+              })
+              .catch((err) => {
+                toast({
+                  title: "Instagram cross-post failed",
+                  description: err?.message || "Network error.",
+                  status: "warning",
+                  duration: 6000,
+                  isClosable: true,
+                });
+              });
+          }
         }
       } catch (error: any) {
         toast({
@@ -778,6 +1026,11 @@ const SnapComposer = React.memo(function SnapComposer({
     t,
     canUseAppFeatures,
     linkedHiveHandle,
+    instagramCrossPost,
+    isMainFeedSnap,
+    farcasterDestination,
+    farcasterEligible,
+    farcasterLinkage,
   ]);
 
   // Detect Ctrl+Enter or Command+Enter and submit - memoized
@@ -1202,6 +1455,97 @@ const SnapComposer = React.memo(function SnapComposer({
             </HStack>
           )}
 
+          {/* Farcaster destination — only if user has a linked Farcaster identity */}
+          {farcasterEligible && (
+            <HStack justify="flex-end" align="center" spacing={2} mb={2} flexWrap="wrap">
+              <Icon as={SiFarcaster} color="primary" boxSize={3.5} />
+              <Text fontSize="xs" color="dim" fontFamily="mono">
+                {farcasterLinkage ? `@${farcasterLinkage.username}` : "Farcaster"}
+              </Text>
+              <ButtonGroup size="xs" isAttached variant="outline">
+                <DestinationPill
+                  active={farcasterDestination === "skatehive"}
+                  onClick={() => setFarcasterDestination("skatehive")}
+                  label="SkateHive"
+                  disabled={isLoading}
+                />
+                <DestinationPill
+                  active={farcasterDestination === "farcaster"}
+                  onClick={() => setFarcasterDestination("farcaster")}
+                  label="Farcaster"
+                  disabled={isLoading || !farcasterSignerApproved}
+                  disabledHint={
+                    !farcasterSignerApproved
+                      ? "Authorize Farcaster posting in Settings first"
+                      : undefined
+                  }
+                />
+                <DestinationPill
+                  active={farcasterDestination === "both"}
+                  onClick={() => setFarcasterDestination("both")}
+                  label="Both"
+                  disabled={isLoading || !farcasterSignerApproved}
+                  disabledHint={
+                    !farcasterSignerApproved
+                      ? "Authorize Farcaster posting in Settings first"
+                      : undefined
+                  }
+                />
+              </ButtonGroup>
+              {!farcasterSignerApproved && (
+                <ChakraLink
+                  as={NextLink}
+                  href="/settings"
+                  fontSize="xs"
+                  fontFamily="mono"
+                  color="primary"
+                  _hover={{ textDecoration: "underline" }}
+                >
+                  Authorize →
+                </ChakraLink>
+              )}
+            </HStack>
+          )}
+
+          {/* Instagram cross-post toggle — only for main-feed snaps */}
+          {isMainFeedSnap && (
+            <HStack
+              justify="flex-end"
+              align="center"
+              spacing={2}
+              mb={2}
+              opacity={hasCrossPostMedia ? 1 : 0.5}
+            >
+              <FaInstagram color="var(--chakra-colors-primary)" size={14} />
+              <Text fontSize="xs" color="dim" fontFamily="mono">
+                {hasCrossPostMedia
+                  ? "Also post to @skatehive on Instagram"
+                  : "Add a photo or video to enable Instagram cross-post"}
+              </Text>
+              <Tooltip
+                label={
+                  hasCrossPostMedia
+                    ? ""
+                    : "Attach an image or video first."
+                }
+                isDisabled={hasCrossPostMedia}
+                hasArrow
+                placement="top"
+              >
+                <Box>
+                  <Switch
+                    size="sm"
+                    colorScheme="green"
+                    isChecked={instagramCrossPost && hasCrossPostMedia}
+                    isDisabled={!hasCrossPostMedia || isLoading}
+                    onChange={(e) => setInstagramCrossPost(e.target.checked)}
+                    aria-label="Cross-post this snap to the SkateHive Instagram"
+                  />
+                </Box>
+              </Tooltip>
+            </HStack>
+          )}
+
           <HStack justify="space-between" mb={0}>
             <HStack spacing={3} align="center" wrap="nowrap">
               {/* Media Upload Button */}
@@ -1463,3 +1807,50 @@ const SnapComposer = React.memo(function SnapComposer({
 });
 
 export default SnapComposer;
+
+function DestinationPill({
+  active,
+  onClick,
+  label,
+  disabled,
+  disabledHint,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+  disabled?: boolean;
+  disabledHint?: string;
+}) {
+  const btn = (
+    <Button
+      onClick={disabled ? undefined : onClick}
+      isDisabled={disabled}
+      bg={active ? "primary" : "transparent"}
+      color={active ? "background" : "dim"}
+      borderColor={active ? "primary" : "border"}
+      borderWidth="1px"
+      fontFamily="mono"
+      fontSize="2xs"
+      fontWeight={active ? "bold" : "medium"}
+      _hover={
+        disabled
+          ? {}
+          : active
+          ? { bg: "accent" }
+          : { bg: "subtle", color: "text" }
+      }
+      _disabled={{ opacity: 0.4, cursor: "not-allowed" }}
+      px={3}
+      h="24px"
+    >
+      {label}
+    </Button>
+  );
+  return disabled && disabledHint ? (
+    <Tooltip label={disabledHint} hasArrow placement="top">
+      <Box>{btn}</Box>
+    </Tooltip>
+  ) : (
+    btn
+  );
+}

--- a/hooks/usePostEdit.ts
+++ b/hooks/usePostEdit.ts
@@ -3,12 +3,23 @@ import { useToast } from "@chakra-ui/react";
 import { useAioha } from "@aioha/react-ui";
 import { KeyTypes } from "@aioha/aioha";
 import { Discussion, Operation } from "@hiveio/dhive";
+import { useLinkedIdentities } from "@/contexts/LinkedIdentityContext";
 
 export type UpgradeAction = "follow" | "edit" | "delete" | "wallet" | "general";
 
 export const usePostEdit = (discussion: Discussion) => {
     const { aioha, user } = useAioha();
+    const { hiveIdentity: userbaseHiveIdentity } = useLinkedIdentities();
     const toast = useToast();
+
+    // The author we'll attempt the edit as. Prefer the active Keychain
+    // user, fall back to the userbase-linked Hive handle (which posts via
+    // the stored encrypted posting key at /api/userbase/hive/comment).
+    const linkedHiveHandle = userbaseHiveIdentity?.handle || null;
+    const effectiveAuthor = user || linkedHiveHandle;
+    // You can only edit your own post — author must match.
+    const canEditThisPost =
+        !!effectiveAuthor && effectiveAuthor === discussion.author;
 
     const [isEditing, setIsEditing] = useState(false);
     const [editedContent, setEditedContent] = useState(discussion.body);
@@ -18,8 +29,8 @@ export const usePostEdit = (discussion: Discussion) => {
     const [upgradeAction, setUpgradeAction] = useState<UpgradeAction>("edit");
 
     const handleEditClick = useCallback(() => {
-        // If no Hive user connected, show upgrade modal
-        if (!user) {
+        // No Hive identity at all — prompt to link/upgrade.
+        if (!canEditThisPost) {
             setUpgradeAction("edit");
             setShowUpgradeModal(true);
             return;
@@ -40,17 +51,17 @@ export const usePostEdit = (discussion: Discussion) => {
         }
         
         setIsEditing(true);
-    }, [discussion.body, discussion.json_metadata, user]);
+    }, [discussion.body, discussion.json_metadata, canEditThisPost]);
 
     const handleDeleteClick = useCallback(() => {
-        // If no Hive user connected, show upgrade modal
+        // Delete still requires Keychain (active-key-equivalent op). The
+        // userbase API doesn't currently expose a delete endpoint, so we
+        // keep the previous gate here intentionally.
         if (!user) {
             setUpgradeAction("delete");
             setShowUpgradeModal(true);
             return;
         }
-        // If user is connected, the actual delete logic is handled elsewhere
-        // This just provides the gate check
         return true;
     }, [user]);
 
@@ -65,7 +76,7 @@ export const usePostEdit = (discussion: Discussion) => {
     }, [discussion.body]);
 
     const handleSaveEdit = useCallback(async () => {
-        if (!user || (editedContent === discussion.body && !selectedThumbnail)) {
+        if (!canEditThisPost || (editedContent === discussion.body && !selectedThumbnail)) {
             setIsEditing(false);
             return;
         }
@@ -76,7 +87,7 @@ export const usePostEdit = (discussion: Discussion) => {
             // Check if no changes were made
             const contentChanged = editedContent.trim() !== discussion.body.trim();
             const thumbnailChanged = selectedThumbnail !== null;
-            
+
             if (!contentChanged && !thumbnailChanged) {
                 toast({
                     title: "No changes detected",
@@ -102,41 +113,64 @@ export const usePostEdit = (discussion: Discussion) => {
                 if (!parsedMetadata.image) {
                     parsedMetadata.image = [];
                 }
-                // Ensure the selected thumbnail is the first in the array
                 if (Array.isArray(parsedMetadata.image)) {
-                    // Remove the thumbnail if it already exists in the array
                     parsedMetadata.image = parsedMetadata.image.filter((img: string) => img !== selectedThumbnail);
-                    // Add it to the beginning
                     parsedMetadata.image.unshift(selectedThumbnail);
                 } else {
                     parsedMetadata.image = [selectedThumbnail];
                 }
             }
 
-            const operation: Operation = [
-                "comment",
-                {
-                    parent_author: discussion.parent_author || "",
-                    parent_permlink: discussion.parent_permlink || discussion.category || "",
-                    author: user,
-                    permlink: discussion.permlink,
-                    title: discussion.title || "",
-                    body: editedContent,
-                    json_metadata: JSON.stringify(parsedMetadata),
-                },
-            ];
+            const author = effectiveAuthor!;
+            const commentPayload = {
+                parent_author: discussion.parent_author || "",
+                parent_permlink: discussion.parent_permlink || discussion.category || "",
+                author,
+                permlink: discussion.permlink,
+                title: discussion.title || "",
+                body: editedContent,
+                json_metadata: JSON.stringify(parsedMetadata),
+            };
 
-            console.log("[EditPost] Broadcasting operation:", JSON.stringify(operation[1], null, 2));
+            let success = false;
+            let errorMessage = "Failed to update post";
 
-            // Use aioha to broadcast the edit
-            const result = await aioha.signAndBroadcastTx([operation], KeyTypes.Posting);
+            if (user) {
+                // Keychain path — broadcast via aioha.
+                const operation: Operation = ["comment", commentPayload];
+                const result = await aioha.signAndBroadcastTx(
+                    [operation],
+                    KeyTypes.Posting
+                );
+                if (result && result.success) {
+                    success = true;
+                } else {
+                    errorMessage =
+                        result?.error?.message || result?.message || errorMessage;
+                }
+            } else {
+                // Userbase path — server decrypts the stored posting key and
+                // broadcasts the same comment op. Re-publishing a comment with
+                // an existing author+permlink is a Hive-native edit.
+                const response = await fetch("/api/userbase/hive/comment", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                        ...commentPayload,
+                        // `type` is used by the route for soft-post telemetry —
+                        // we send "edit" so it can skip soft-post insertion.
+                        type: "edit",
+                    }),
+                });
+                const data = await response.json().catch(() => ({}));
+                if (response.ok) {
+                    success = true;
+                } else {
+                    errorMessage = data?.error || errorMessage;
+                }
+            }
 
-            console.log("[EditPost] Broadcast result:", result);
-            console.log("[EditPost] result.success:", result?.success);
-            console.log("[EditPost] result.result:", result?.result);
-            console.log("[EditPost] result.error:", result?.error);
-
-            if (result && result.success) {
+            if (success) {
                 toast({
                     title: "Post updated on blockchain!",
                     description: "Changes may take a few seconds to appear after refresh.",
@@ -147,26 +181,9 @@ export const usePostEdit = (discussion: Discussion) => {
 
                 // Update the local discussion body and metadata
                 discussion.body = editedContent;
-                if (selectedThumbnail) {
-                    try {
-                        const updatedMetadata = JSON.parse(discussion.json_metadata || '{}');
-                        if (!updatedMetadata.image) {
-                            updatedMetadata.image = [];
-                        }
-                        if (Array.isArray(updatedMetadata.image)) {
-                            updatedMetadata.image = updatedMetadata.image.filter((img: string) => img !== selectedThumbnail);
-                            updatedMetadata.image.unshift(selectedThumbnail);
-                        } else {
-                            updatedMetadata.image = [selectedThumbnail];
-                        }
-                        discussion.json_metadata = JSON.stringify(updatedMetadata);
-                    } catch (e) {
-                        console.warn('Failed to update local metadata');
-                    }
-                }
+                discussion.json_metadata = JSON.stringify(parsedMetadata);
                 setIsEditing(false);
             } else {
-                const errorMessage = result?.error?.message || result?.message || "Failed to update post";
                 throw new Error(errorMessage);
             }
         } catch (error: any) {
@@ -181,7 +198,7 @@ export const usePostEdit = (discussion: Discussion) => {
         } finally {
             setIsSaving(false);
         }
-    }, [user, editedContent, discussion, aioha, toast, selectedThumbnail]);
+    }, [canEditThisPost, effectiveAuthor, user, editedContent, discussion, aioha, toast, selectedThumbnail]);
 
     return {
         isEditing,
@@ -198,7 +215,13 @@ export const usePostEdit = (discussion: Discussion) => {
         showUpgradeModal,
         upgradeAction,
         closeUpgradeModal,
-        isHiveConnected: !!user,
+        // True if the user can post via Hive at all (Keychain OR stored
+        // posting key). Callers use this to show/hide the edit affordance.
+        isHiveConnected: !!effectiveAuthor,
+        // True when the active identity matches the post's author. Use
+        // this for the actual "Edit" menu item — owning a post is per-post,
+        // while isHiveConnected is per-user.
+        canEditThisPost,
     };
 };
 

--- a/lib/farcaster/neynar.ts
+++ b/lib/farcaster/neynar.ts
@@ -233,18 +233,24 @@ export async function deleteReaction(
   return { success: true };
 }
 
-// ─── Casts (replies) ────────────────────────────────────────
+// ─── Casts (replies + root casts) ───────────────────────────
+
+export type CastEmbed =
+  | { url: string }
+  | { cast_id: { fid: number; hash: string } };
 
 export async function publishCast(
   signerUuid: string,
   text: string,
-  parentHash?: string
+  parentHash?: string,
+  embeds?: CastEmbed[]
 ): Promise<{ success: boolean; hash?: string; error?: string }> {
   const apiKey = getApiKey();
   if (!apiKey) return { success: false, error: "API key not configured" };
 
-  const body: Record<string, string> = { signer_uuid: signerUuid, text };
+  const body: Record<string, unknown> = { signer_uuid: signerUuid, text };
   if (parentHash) body.parent = parentHash;
+  if (embeds && embeds.length > 0) body.embeds = embeds.slice(0, 2);
 
   const res = await fetch(`${NEYNAR_BASE}/v2/farcaster/cast`, {
     method: "POST",

--- a/lib/farcaster/neynar.ts
+++ b/lib/farcaster/neynar.ts
@@ -243,7 +243,8 @@ export async function publishCast(
   signerUuid: string,
   text: string,
   parentHash?: string,
-  embeds?: CastEmbed[]
+  embeds?: CastEmbed[],
+  channelId?: string
 ): Promise<{ success: boolean; hash?: string; error?: string }> {
   const apiKey = getApiKey();
   if (!apiKey) return { success: false, error: "API key not configured" };
@@ -251,6 +252,7 @@ export async function publishCast(
   const body: Record<string, unknown> = { signer_uuid: signerUuid, text };
   if (parentHash) body.parent = parentHash;
   if (embeds && embeds.length > 0) body.embeds = embeds.slice(0, 2);
+  if (channelId) body.channel_id = channelId;
 
   const res = await fetch(`${NEYNAR_BASE}/v2/farcaster/cast`, {
     method: "POST",


### PR DESCRIPTION
Closes #96

## Summary
- Destination selector in the **snap composer** (`SkateHive` / `Farcaster` / `Both`) for users with a linked Farcaster identity. Signer approval gates `Farcaster`/`Both` with a tooltip + `Authorize →` link to `/settings`.
- New `POST /api/farcaster/cast` route for root casts (mirrors `/api/farcaster/reply` signer validation). `lib/farcaster/neynar.ts` `publishCast()` gains an `embeds` arg.
- Hive snap `json_metadata.crosspost.farcaster = { fid, username }` is added when cross-posting, so the SkateHive ↔ Farcaster link is queryable on-chain.
- `SkateHive + Farcaster`: snap posts to Hive first, then fires the cast as **fire-and-forget** (same pattern as the existing Instagram cross-post). Cast contains the snap body + snap URL; embed renders the existing SkateHive `fc:frame` preview from `/user/[username]/snap/[permlink]`.
- `Farcaster only`: skips Hive entirely; first attached image is used as the embed and `skatehive.app` is appended.

## Notable design choices
- **Snap composer only** (not the long-form `/compose`). Snaps map naturally to Farcaster's 1024-char cast limit.
- **Cast hash is not back-written to Hive.** Would require a second `comment_update` broadcast. Future reconciliation: search Neynar for casts by the linked fid whose embed URL matches the snap URL.
- New copy is hardcoded English (matches the existing Instagram cross-post strings, which are also hardcoded).

## Acceptance criteria (from #96)
- [x] Farcaster-capable users can choose SkateHive only, Farcaster only, or both
- [x] SkateHive snaps remain normal snaps while storing Farcaster linkage metadata
- [x] Farcaster posts include text, images when present, and the SkateHive URL at the bottom
- [x] SkateHive URL placement preserves embed/miniapp preview behavior (uses `embeds[].url` + existing `fc:frame` meta on snap pages)
- [x] Failure handling is defined for partial success cases
- [x] Resulting linkage is durable enough for future sync/analytics/navigation

## Test plan
- [ ] Open the snap composer with no Farcaster identity linked → no destination selector appears; current behavior unchanged.
- [ ] Link Farcaster but skip signer approval → SkateHive pill enabled, Farcaster/Both disabled with tooltip + "Authorize →" link.
- [ ] Approve signer; post a snap in `Both` mode → snap appears on SkateHive, cast appears in Warpcast with body + snap URL, SkateHive frame embed renders, Hive `json_metadata.crosspost.farcaster = { fid, username }`.
- [ ] `Farcaster only` mode with an image attached → cast publishes with first image as embed and `skatehive.app` URL appended; no Hive snap is created.
- [ ] Force a cast failure (e.g. revoke signer between toggle and submit) on `Both` → warning toast shown, Hive snap still landed, composer closes normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-platform posting: post simultaneously to Hive and Farcaster from the composer
  * Farcaster casts now support embeds including URLs and cast references
  * Channel selection available for Farcaster posts
  * Instagram cross-posting support for eligible snaps
  * Redesigned composer UI with platform selection toggles and channel options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SkateHive/skatehive3.0/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->