### PR TITLE
fix: open ConnectionModal instead of dead /sign-in route in settings

### DIFF
--- a/components/settings/UserbaseAccountSettings.tsx
+++ b/components/settings/UserbaseAccountSettings.tsx
@@ -73,17 +73,16 @@ export default function UserbaseAccountSettings() {
           onSuccess={({ fid, username }: any) => {
             setIsFarcasterAuthInProgress(false);
             setIsConnectionModalOpen(false);
-            setTimeout(() => { farcasterAuth.signOut(); }, 100);
             const displayName = username ? `@${username}` : fid ? `#${fid}` : "user";
             setTimeout(() => {
-              toast({ status: "success", title: "Connected to Farcaster!",
-                description: `Welcome, ${displayName}!`, duration: 3000 });
-            }, 200);
+              toast({ status: "success", title: t("auth.connectedSuccess"),
+                description: `${t("auth.welcome")} ${displayName}!`, duration: 3000 });
+            }, 100);
           }}
           onError={(error: any) => {
             setIsFarcasterAuthInProgress(false);
-            toast({ status: "error", title: "Authentication failed",
-              description: error?.message || "Failed to authenticate with Farcaster",
+            toast({ status: "error", title: t("auth.authenticationFailed"),
+              description: error?.message || t("auth.farcasterAuthFailed"),
               duration: 5000 });
           }}
         />

--- a/components/settings/UserbaseAccountSettings.tsx
+++ b/components/settings/UserbaseAccountSettings.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import React from "react";
-import NextLink from "next/link";
+import React, { useState, useCallback } from "react";
 import {
   Box,
+  Button,
   Heading,
-  Link,
   Text,
+  useToast,
   VStack,
 } from "@chakra-ui/react";
 import { useTranslations } from "@/contexts/LocaleContext";
@@ -15,21 +15,79 @@ import UserbaseIdentitiesSection from "@/components/userbase/UserbaseIdentitiesS
 import UserbasePostingKeyPanel from "@/components/userbase/UserbasePostingKeyPanel";
 import UserbaseMergePanel from "@/components/userbase/UserbaseMergePanel";
 import HiveSponsorshipInfo from "@/components/userbase/HiveSponsorshipInfo";
+import HiveLoginModal from "@/components/layout/HiveLoginModal";
+import ConnectionModal from "@/components/layout/ConnectionModal";
+import { FarcasterAuthIsland, useFarcasterAuthMethods } from "@/components/farcaster/FarcasterAuthIsland";
+import { useAioha } from "@aioha/react-ui";
 
 export default function UserbaseAccountSettings() {
   const t = useTranslations();
   const { user } = useUserbaseAuth();
+  const { aioha } = useAioha();
+  const toast = useToast();
+  const [modalDisplayed, setModalDisplayed] = useState(false);
+  const [isConnectionModalOpen, setIsConnectionModalOpen] = useState(false);
+  const [isFarcasterAuthInProgress, setIsFarcasterAuthInProgress] = useState(false);
+  const farcasterAuth = useFarcasterAuthMethods();
+
+  const handleHiveLogin = useCallback(async () => {
+    setIsConnectionModalOpen(false);
+    await aioha.logout();
+    setModalDisplayed(true);
+  }, [aioha]);
+
+  const handleFarcasterConnect = useCallback(() => {
+    if (isFarcasterAuthInProgress) return;
+    setIsFarcasterAuthInProgress(true);
+    try {
+      farcasterAuth.connect();
+    } catch {
+      setIsFarcasterAuthInProgress(false);
+    }
+  }, [isFarcasterAuthInProgress, farcasterAuth]);
 
   if (!user) {
     return (
-      <Box textAlign="center" py={10}>
-        <Text color="primary" mb={3}>
-          {t("settings.signInToManage")}
-        </Text>
-        <Link as={NextLink} href="/sign-in" color="primary">
-          {t("auth.signIn")}
-        </Link>
-      </Box>
+      <>
+        <Box textAlign="center" py={10}>
+          <Text color="primary" mb={3}>
+            {t("settings.signInToManage")}
+          </Text>
+          <Button colorScheme="green" onClick={() => setIsConnectionModalOpen(true)}>
+            {t("auth.signIn")}
+          </Button>
+        </Box>
+        <ConnectionModal
+          isOpen={isConnectionModalOpen}
+          onClose={() => setIsConnectionModalOpen(false)}
+          onHiveLogin={handleHiveLogin}
+          onFarcasterConnect={handleFarcasterConnect}
+          isFarcasterAuthInProgress={isFarcasterAuthInProgress}
+        />
+        <HiveLoginModal
+          isOpen={modalDisplayed}
+          onClose={() => setModalDisplayed(false)}
+          onSuccess={() => setIsConnectionModalOpen(false)}
+        />
+        <FarcasterAuthIsland
+          onSuccess={({ fid, username }: any) => {
+            setIsFarcasterAuthInProgress(false);
+            setIsConnectionModalOpen(false);
+            setTimeout(() => { farcasterAuth.signOut(); }, 100);
+            const displayName = username ? `@${username}` : fid ? `#${fid}` : "user";
+            setTimeout(() => {
+              toast({ status: "success", title: "Connected to Farcaster!",
+                description: `Welcome, ${displayName}!`, duration: 3000 });
+            }, 200);
+          }}
+          onError={(error: any) => {
+            setIsFarcasterAuthInProgress(false);
+            toast({ status: "error", title: "Authentication failed",
+              description: error?.message || "Failed to authenticate with Farcaster",
+              duration: 5000 });
+          }}
+        />
+      </>
     );
   }
 

--- a/lib/i18n/locales/en.ts
+++ b/lib/i18n/locales/en.ts
@@ -59,6 +59,8 @@ export const en = {
     authenticationFailed: 'Authentication failed',
     connectionFailed: 'Connection Failed',
     connectedSuccess: 'Connected successfully!',
+    welcome: 'Welcome,',
+    farcasterAuthFailed: 'Failed to authenticate with Farcaster',
   },
   signIn: {
     title: 'Sign in',

--- a/lib/i18n/locales/es.ts
+++ b/lib/i18n/locales/es.ts
@@ -59,6 +59,8 @@ export const es = {
     authenticationFailed: 'Autenticación fallida',
     connectionFailed: 'Conexión Fallida',
     connectedSuccess: '¡Conectado exitosamente!',
+    welcome: 'Bienvenido,',
+    farcasterAuthFailed: 'Error al autenticar con Farcaster',
   },
   signIn: {
     title: 'Iniciar sesión',

--- a/lib/i18n/locales/lg.ts
+++ b/lib/i18n/locales/lg.ts
@@ -59,6 +59,8 @@ export const lg = {
     authenticationFailed: 'Okukkiriza Byetagganya',
     connectionFailed: 'Okukoboka Byetagganya',
     connectedSuccess: 'Okukoboka Okukola Bulungi!',
+    welcome: 'Tukwanirizza,',
+    farcasterAuthFailed: 'Failed to authenticate with Farcaster',
   },
   signIn: {
     title: 'Kwingira',

--- a/lib/i18n/locales/pt-BR.ts
+++ b/lib/i18n/locales/pt-BR.ts
@@ -59,6 +59,8 @@ export const ptBR = {
     authenticationFailed: 'Autenticação falhou',
     connectionFailed: 'Conexão Falhou',
     connectedSuccess: 'Conectado com sucesso!',
+    welcome: 'Bem-vindo,',
+    farcasterAuthFailed: 'Falha ao autenticar com Farcaster',
   },
   signIn: {
     title: 'Entrar',

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -55,6 +55,8 @@ export interface TranslationSchema {
     authenticationFailed: string;
     connectionFailed: string;
     connectedSuccess: string;
+    welcome: string;
+    farcasterAuthFailed: string;
   };
   signIn: {
     title: string;


### PR DESCRIPTION
## What changed
- `components/settings/UserbaseAccountSettings.tsx` — replaced broken 
  `/sign-in` link (404) with a button that opens `ConnectionModal`

## Behavior
- Settings → App Account → "Sign In" now opens the full ConnectionModal 
  with all 4 entry points: Email, EVM wallet, Farcaster, and Hive
- Hive option chains through to HiveLoginModal exactly as AuthButton does

## What was NOT changed
- No new files, no new context
- Follows the exact same pattern as AuthButton.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced account settings with integrated Hive and Farcaster authentication UI
  * Added modal-based login flow for streamlined authentication experience
  * Implemented Farcaster connection with automatic success confirmation

* **Improvements**
  * Added safeguards to prevent duplicate connection attempts
  * Improved error handling with user notifications for authentication failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SkateHive/skatehive3.0/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->