### PR TITLE
fix: autoembed formatted YouTube markdown

### DIFF
--- a/lib/markdown/MarkdownRenderer.ts
+++ b/lib/markdown/MarkdownRenderer.ts
@@ -18,6 +18,47 @@ const mentionValidationCache = new LRUCache<string, boolean>(1000, 60 * 60 * 100
 // Import Hive account validation
 const { checkHiveAccountExists } = require('@/lib/utils/hiveAccountUtils');
 
+const YOUTUBE_ID_PATTERN = "[a-zA-Z0-9_-]{11}";
+const YOUTUBE_URL_PATTERN = new RegExp(
+    `https?:\\/\\/(?:www\\.|m\\.)?(?:(?:youtube(?:-nocookie)?\\.com\\/(?:watch\\?(?:[^\\s<>()]*&)?v=|embed\\/|shorts\\/)|youtu\\.be\\/)${YOUTUBE_ID_PATTERN}(?:[?&][^\\s<>()*]*)?)`,
+    "i"
+);
+
+function getYouTubePlaceholder(rawUrl: string): string | null {
+    const normalizedUrl = rawUrl.trim().replace(/^<|>$/g, "");
+    try {
+        const url = new URL(normalizedUrl);
+        const host = url.hostname.replace(/^www\./, "").replace(/^m\./, "");
+        let videoId: string | null = null;
+        let isShort = false;
+
+        if (host === "youtu.be") {
+            videoId = url.pathname.split("/").filter(Boolean)[0] || null;
+        } else if (host === "youtube.com" || host === "youtube-nocookie.com") {
+            if (url.pathname === "/watch") {
+                videoId = url.searchParams.get("v");
+            } else {
+                const [, type, id] = url.pathname.match(/^\/(embed|shorts)\/([a-zA-Z0-9_-]{11})/) || [];
+                videoId = id || null;
+                isShort = type === "shorts";
+            }
+        }
+
+        if (!videoId || !/^[a-zA-Z0-9_-]{11}$/.test(videoId)) {
+            return null;
+        }
+
+        return `[[YOUTUBE:${isShort ? "s:" : ""}${videoId}]]`;
+    } catch {
+        return null;
+    }
+}
+
+function replaceYouTubeLine(match: string, prefix: string, rawUrl: string) {
+    const placeholder = getYouTubePlaceholder(rawUrl);
+    return placeholder ? `${prefix}${placeholder}` : match;
+}
+
 // Simple function to get DOMPurify instance, sanitize on both server and client
 function getSanitizedHTML(html: string): string {
     // isomorphic-dompurify works on both server and client
@@ -173,16 +214,23 @@ export function processMediaContent(content: string): string {
         /<iframe[^>]*src=["'](?:https?:)?\/\/(?:www\.)?(?:youtube(?:-nocookie)?\.com\/embed\/|youtu\.be\/)([a-zA-Z0-9_-]{11})[^"']*["'][^>]*><\/iframe>/gim,
         (_match, videoId) => `[[YOUTUBE:${videoId}]]`
     );
-    // YouTube Shorts direct links — captured separately and tagged with an
-    // "s:" prefix so the dispatcher can render at 9/16 instead of 16/9.
+
+    // YouTube links wrapped by markdown formatting should still autoembed.
+    // Examples: [video](https://youtu.be/...), **https://youtube...**, or
+    // quoted/listed standalone YouTube URLs.
     processedContent = processedContent.replace(
-        /^https?:\/\/(?:www\.)?youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})[\S]*/gim,
-        (_match, videoId) => `[[YOUTUBE:s:${videoId}]]`
+        new RegExp(
+            `^(\\s*(?:>\\s*)?(?:(?:[-*+]|\\d+\\.)\\s+)?)!?\\[[^\\n]*\\]\\((${YOUTUBE_URL_PATTERN.source})\\)\\s*$`,
+            "gim"
+        ),
+        replaceYouTubeLine
     );
-    // YouTube direct links (regular videos — must run AFTER the Shorts rule)
     processedContent = processedContent.replace(
-        /^https?:\/\/(?:www\.)?(?:youtube(?:-nocookie)?\.com\/(?:watch\?(?:[^\s]*&)?v=|embed\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})[\S]*/gim,
-        (_match, videoId) => `[[YOUTUBE:${videoId}]]`
+        new RegExp(
+            `^(\\s*(?:>\\s*)?(?:(?:[-*+]|\\d+\\.)\\s+)?)(?:\\*\\*|__|\\*|_)?<?(${YOUTUBE_URL_PATTERN.source})>?(?:\\*\\*|__|\\*|_)?\\s*$`,
+            "gim"
+        ),
+        replaceYouTubeLine
     );
     // Vimeo iframe embeds
     processedContent = processedContent.replace(

--- a/lib/markdown/__tests__/MarkdownRenderer.test.ts
+++ b/lib/markdown/__tests__/MarkdownRenderer.test.ts
@@ -1,0 +1,87 @@
+import { processMediaContent } from "../MarkdownRenderer";
+
+const tests: Array<() => void | Promise<void>> = [];
+let hasFailures = false;
+
+function describe(name: string, fn: () => void) {
+  console.log(`\n${name}`);
+  fn();
+}
+
+function it(name: string, fn: () => void | Promise<void>) {
+  tests.push(async () => {
+    try {
+      await fn();
+      console.log(`  ok ${name}`);
+    } catch (error) {
+      console.error(`  fail ${name}`);
+      console.error(`     ${error}`);
+      hasFailures = true;
+    }
+  });
+}
+
+function assertIncludes(actual: string, expected: string, message?: string) {
+  if (!actual.includes(expected)) {
+    throw new Error(message || `Expected "${actual}" to include "${expected}"`);
+  }
+}
+
+function assertNotIncludes(actual: string, expected: string, message?: string) {
+  if (actual.includes(expected)) {
+    throw new Error(message || `Expected "${actual}" not to include "${expected}"`);
+  }
+}
+
+describe("processMediaContent YouTube autoembed", () => {
+  it("converts standalone YouTube watch URLs", () => {
+    const result = processMediaContent("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+
+    assertIncludes(result, "[[YOUTUBE:dQw4w9WgXcQ]]");
+  });
+
+  it("converts markdown links that point to YouTube", () => {
+    const result = processMediaContent("[watch this](https://youtu.be/dQw4w9WgXcQ)");
+
+    assertIncludes(result, "[[YOUTUBE:dQw4w9WgXcQ]]");
+    assertNotIncludes(result, "[watch this]");
+  });
+
+  it("converts formatted standalone YouTube links", () => {
+    const result = processMediaContent("**https://youtu.be/dQw4w9WgXcQ**");
+
+    assertIncludes(result, "[[YOUTUBE:dQw4w9WgXcQ]]");
+  });
+
+  it("converts formatted YouTube links with underscore IDs", () => {
+    const result = processMediaContent("__https://youtu.be/dQw4w9W_XcQ__");
+
+    assertIncludes(result, "[[YOUTUBE:dQw4w9W_XcQ]]");
+  });
+
+  it("converts watch URLs with query params before the video ID", () => {
+    const result = processMediaContent(
+      "*https://www.youtube.com/watch?feature=share&v=dQw4w9WgXcQ*"
+    );
+
+    assertIncludes(result, "[[YOUTUBE:dQw4w9WgXcQ]]");
+  });
+
+  it("preserves quote and list prefixes around autoembedded links", () => {
+    const result = processMediaContent("> - https://youtu.be/dQw4w9WgXcQ");
+
+    assertIncludes(result, "> - [[YOUTUBE:dQw4w9WgXcQ]]");
+  });
+
+  it("keeps shorts tagged for vertical rendering", () => {
+    const result = processMediaContent("https://www.youtube.com/shorts/dQw4w9WgXcQ");
+
+    assertIncludes(result, "[[YOUTUBE:s:dQw4w9WgXcQ]]");
+  });
+});
+
+Promise.all(tests.map((test) => test())).then(() => {
+  if (hasFailures) {
+    process.exit(1);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "next lint",
     "lint:fix": "next lint --fix",
     "type-check": "tsc --noEmit",
-    "test": "tsx lib/utils/__tests__/LRUCache.test.ts && tsx lib/utils/__tests__/hashUtils.test.ts",
+    "test": "tsx lib/utils/__tests__/LRUCache.test.ts && tsx lib/utils/__tests__/hashUtils.test.ts && tsx lib/markdown/__tests__/MarkdownRenderer.test.ts",
     "test:lru": "tsx lib/utils/__tests__/LRUCache.test.ts",
     "test:hash": "tsx lib/utils/__tests__/hashUtils.test.ts",
     "approve-builds": "pnpm config set strict-peer-dependencies false && pnpm install",


### PR DESCRIPTION
## Summary
- autoembed YouTube URLs even when they are wrapped in markdown links or emphasis markers
- preserve quote/list prefixes and Shorts handling
- add markdown renderer regression tests, including underscore IDs and watch URLs with query params

## Verification
- pnpm test
- pnpm lint (passes with existing warnings)
- pnpm build
- visual approved in Telegram thread with real EnhancedMarkdownRenderer screenshot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced YouTube link detection and embedding to support multiple URL formats
  * Added dedicated support for YouTube Shorts with optimized vertical rendering

* **Tests**
  * Introduced comprehensive test suite validating YouTube embedding behavior across various link formats and scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->