### PR TITLE
fix(farcaster): replies link the related post; instagram preview skips dedupe early-returns

### DIFF
--- a/app/api/instagram/force-post/route.ts
+++ b/app/api/instagram/force-post/route.ts
@@ -218,7 +218,10 @@ export async function POST(request: NextRequest) {
     .eq("hive_permlink", hivePermlink)
     .limit(1);
   const existing = existingRows?.[0];
-  if (existing && existing.status === "published") {
+  // Preview requests skip these early returns so they always reach the
+  // preview branch below, which surfaces the dedupe state as a non-blocking
+  // warning (the moderator may still want to see the second attempt's caption).
+  if (!isPreview && existing && existing.status === "published") {
     return NextResponse.json(
       {
         success: true,
@@ -230,7 +233,7 @@ export async function POST(request: NextRequest) {
     );
   }
   let existingRetryableId: string | null = null;
-  if (existing) {
+  if (!isPreview && existing) {
     const ageMs = Date.now() - new Date(existing.created_at).getTime();
     if (existing.status === "failed" || (existing.status === "queued" && ageMs > 10 * 60 * 1000)) {
       existingRetryableId = existing.id as string;

--- a/components/homepage/SnapComposer.tsx
+++ b/components/homepage/SnapComposer.tsx
@@ -798,12 +798,19 @@ const SnapComposer = React.memo(function SnapComposer({
       }
       setIsLoading(true);
       try {
-        const castText = buildSnapCastText(commentBody, APP_CONFIG.ORIGIN);
-        // No SkateHive snap exists in this branch, so we can't fall back
-        // to a snap URL — embed media directly: images first (up to 2),
-        // else video for the inline player, else nothing.
+        // A reply/comment links the RELATED post being discussed, not itself.
+        // A top-level snap has no Hive URL in this Farcaster-only branch, so
+        // it falls back to the site origin.
+        const fcUrl = isMainFeedSnap
+          ? APP_CONFIG.ORIGIN
+          : `${APP_CONFIG.ORIGIN.replace(/\/$/, "")}/post/${pa}/${pp}`;
+        const castText = buildSnapCastText(commentBody, fcUrl);
+        // Snap → embed media directly (images first, else video). Reply →
+        // embed the related post so it doesn't read as a standalone post.
         let embeds: { url: string }[] = [];
-        if (compressedImages.length > 0) {
+        if (!isMainFeedSnap) {
+          embeds = [{ url: fcUrl }];
+        } else if (compressedImages.length > 0) {
           embeds = compressedImages.slice(0, 2).map((img) => ({ url: img.url }));
         } else if (videoUrl) {
           embeds = [{ url: videoUrl }];
@@ -1109,19 +1116,29 @@ const SnapComposer = React.memo(function SnapComposer({
             // Farcaster (awaited so the progress toast closes when done)
             const farcasterTask: Promise<void> = (async () => {
               if (!willFarcaster) return;
-              const castText = buildSnapCastText(commentBody, snapUrl);
+              // A top-level main-feed snap IS the content → link the snap and
+              // embed its media. A reply/comment (feed reply, or a comment on
+              // a blog/mag post) should link the RELATED post being discussed
+              // rather than presenting the comment as its own Farcaster post.
+              const farcasterUrl = isMainFeedSnap
+                ? snapUrl
+                : `${APP_CONFIG.ORIGIN.replace(/\/$/, "")}/post/${pa}/${pp}`;
+              const castText = buildSnapCastText(commentBody, farcasterUrl);
               // Embed selection:
-              //   - images → embed up to 2 image URLs directly (Warpcast
+              //   - snap images → embed up to 2 image URLs directly (Warpcast
               //     renders inline image previews — best UX).
-              //   - video  → snapUrl FIRST (frame renders the SkateHive
-              //     thumbnail), videoUrl SECOND for clients with inline
-              //     video support.
-              //   - text   → snapUrl alone (frame card).
-              const embeds = buildSnapCastEmbeds({
-                snapUrl,
-                imageUrls: compressedImages.map((img) => img.url),
-                videoUrl: videoUrl || null,
-              });
+              //   - snap video  → snapUrl FIRST (frame renders the SkateHive
+              //     thumbnail), videoUrl SECOND for inline-video clients.
+              //   - snap text   → snapUrl alone (frame card).
+              //   - reply       → the related post alone (frame card), so the
+              //     cast points at what's being discussed, not the comment.
+              const embeds = isMainFeedSnap
+                ? buildSnapCastEmbeds({
+                    snapUrl: farcasterUrl,
+                    imageUrls: compressedImages.map((img) => img.url),
+                    videoUrl: videoUrl || null,
+                  })
+                : [{ url: farcasterUrl }];
               try {
                 const res = await fetch("/api/farcaster/cast", {
                   method: "POST",


### PR DESCRIPTION
## What

Two cross-posting fixes that were sitting uncommitted locally.

### 1. Farcaster replies link the related post (not themselves)
`SnapComposer` previously cross-posted **every** snap/comment to Farcaster as if it were a standalone post — linking and embedding itself. A feed reply, or a comment on a blog/mag post, would read as its own Farcaster post.

Now gated on `isMainFeedSnap` (`pp === THREADS.PERMLINK`):
- **Top-level main-feed snap** → links its own `snapUrl` and embeds its media (images first, else video), as before.
- **Reply / comment** → links and embeds the **related post** (`/post/{pa}/{pp}`) so the cast points at what's being discussed.

### 2. Instagram preview skips dedupe early-returns
In `api/instagram/force-post`, a `preview` request was short-circuited by the "already published" and retryable early returns, so it never reached the dedicated preview branch. Those returns are now gated on `!isPreview`; previews always reach the preview branch, which surfaces the dedupe state as a **non-blocking warning** (a moderator may still want to see the second attempt's caption). **Non-preview (real post) behavior is unchanged** — `!isPreview` is `true` on that path.

## Verification
- `tsc --noEmit` → exit 0 (no type errors)
- All referenced identifiers (`isPreview`, `isMainFeedSnap`, `pa`, `pp`) confirmed defined in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preview requests now properly continue through deduplication flow, returning preview-specific data and warnings instead of early success responses
  * Disabled automatic retry setup during preview mode to prevent unintended queue operations

* **Improvements**
  * Enhanced Farcaster cross-posting for replies to embed context-aware references to the related post rather than duplicating media embeds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->