### PR TITLE
fix(#128): markdown preview shows raw syntax instead of rendered formatting

### DIFF
--- a/components/compose/MarkdownEditor.tsx
+++ b/components/compose/MarkdownEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { Box, Textarea, HStack, IconButton, Button, Flex, Text, useColorModeValue } from "@chakra-ui/react";
 import { useDropzone } from "react-dropzone";
-import HiveMarkdown from "../shared/HiveMarkdown";
+import { EnhancedMarkdownRenderer } from "../markdown/EnhancedMarkdownRenderer";
 import { FaColumns } from "react-icons/fa";
 import { TbGif } from "react-icons/tb";
 import { MdPermMedia } from "react-icons/md";
@@ -315,7 +315,7 @@ export default function MarkdownEditor({
               Preview
             </Text>
             <Box color={textPrimary} fontSize="15px" lineHeight="1.7">
-              <HiveMarkdown markdown={markdown} rawIframes={true} />
+              <EnhancedMarkdownRenderer content={markdown} />
             </Box>
           </Box>
           <Box
@@ -378,7 +378,7 @@ export default function MarkdownEditor({
           maxHeight="50%"
           overflow="auto"
         >
-          <HiveMarkdown markdown={markdown} rawIframes={true} />
+          <EnhancedMarkdownRenderer content={markdown} />
         </Box>
       )}
 


### PR DESCRIPTION
## What changed
- components/compose/MarkdownEditor.tsx — replaced HiveMarkdown 
  (rawIframes={true} mode) with EnhancedMarkdownRenderer in both the 
  split-view pane and the bottom preview panel

## Why
The rawIframes mode was a workaround to prevent video embeds from 
reloading on every keystroke, but it skipped the entire markdown 
processing pipeline as a side effect — bold, italic, headings, etc 
all rendered as raw syntax instead of formatted text.

EnhancedMarkdownRenderer (already used for published posts and 
EditPostModal) solves both problems together: full markdown rendering 
via MarkdownProcessor + stable iframe embeds via positional React keys 
and LRU caching.

## Tested
- Bold, italic, headings now render correctly in both preview panes
- Video embed (YouTube) remains stable — no reload/flicker after 
  typing additional text

Closes #128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated markdown rendering in the compose editor across split-view and preview modes with an improved renderer implementation for enhanced consistency and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->