### PR TITLE
fix: avatar fallback shown despite valid profile image

### DIFF
--- a/components/profile/ProfileHeader.tsx
+++ b/components/profile/ProfileHeader.tsx
@@ -449,6 +449,8 @@ export default memo(ProfileHeader, (prevProps, nextProps) => {
     prevProps.username === nextProps.username &&
     prevProps.profileData.ethereum_address ===
       nextProps.profileData.ethereum_address &&
+    prevProps.profileData.profileImage === nextProps.profileData.profileImage &&
+    prevProps.hiveProfileData?.profileImage === nextProps.hiveProfileData?.profileImage &&
     prevProps.isOwner === nextProps.isOwner &&
     prevProps.isUserbaseOwner === nextProps.isUserbaseOwner &&
     prevProps.user === nextProps.user &&

--- a/hooks/useProfileData.ts
+++ b/hooks/useProfileData.ts
@@ -44,88 +44,79 @@ export default function useProfileData(username: string, hiveAccount: HiveAccoun
 
     useEffect(() => {
         if (!username || !hasHiveAccount) return;
+        
+        let profileImage = "";
+        let coverImage = "";
+        let website = "";
+        let instagram = "";
+        let ethereum_address = "";
+        let video_parts: VideoPart[] = [];
+        let vote_weight = 51;
+        let zineCover = "";
+        let svs_profile = "";
 
-        const fetchProfileInfo = async () => {
+        if (postingMetadata) {
+            try {
+                const parsedMetadata = JSON.parse(postingMetadata);
+                const profile = parsedMetadata?.profile || {};
+                profileImage = profile.profile_image || "";
+                coverImage = profile.cover_image || "";
+                website = profile.website || "";
+                // IG handle: prefer direct field, fall back to nested
+                // social.instagram, then parse from a website URL.
+                if (typeof profile.instagram === "string") {
+                    instagram = profile.instagram.trim();
+                } else if (
+                    profile.social &&
+                    typeof profile.social.instagram === "string"
+                ) {
+                    instagram = profile.social.instagram.trim();
+                } else if (typeof profile.website === "string") {
+                    const m = profile.website.match(/instagram\.com\/([A-Za-z0-9._]+)/);
+                    if (m) instagram = m[1];
+                }
+            } catch (err) {
+                console.error("Failed to parse profile metadata", err);
+            }
+        }
+
+        if (jsonMetadata) {
+            try {
+                const rawMetadata = JSON.parse(jsonMetadata);
+                const parsedMetadata = migrateLegacyMetadata(rawMetadata);
+                ethereum_address = parsedMetadata.extensions?.wallets?.primary_wallet || "";
+                video_parts = parsedMetadata.extensions?.video_parts || [];
+                const defaultWeight = parsedMetadata.extensions?.settings?.voteSettings?.default_voting_weight;
+                vote_weight = typeof defaultWeight === 'number' ? Math.round(defaultWeight / 100) : 51;
+                zineCover = parsedMetadata.extensions?.settings?.appSettings?.zineCover || "";
+                svs_profile = parsedMetadata.extensions?.settings?.appSettings?.svs_profile || "";
+            } catch (err) {
+                console.error("Failed to parse json_metadata", err);
+            }
+        }
+
+        updateProfileData({ name: username, profileImage, coverImage, website, instagram, ethereum_address, video_parts, vote_weight, zineCover, svs_profile });
+
+        // --- Phase 2: bridge API (async, can fail independently) ---
+        (async () => {
             try {
                 debug.fetch("fetching profile + power", { username });
                 const profileInfo = await getProfile(username);
                 const powerInfo = await getAccountWithPower(username);
 
-                let profileImage = "";
-                let coverImage = "";
-                let website = "";
-                let instagram = "";
-                let ethereum_address = "";
-                let video_parts: VideoPart[] = [];
-                let vote_weight = 51;
-                let zineCover = "";
-                let svs_profile = "";
-
-                if (postingMetadata) {
-                    try {
-                        const parsedMetadata = JSON.parse(postingMetadata);
-                        const profile = parsedMetadata?.profile || {};
-                        profileImage = profile.profile_image || "";
-                        coverImage = profile.cover_image || "";
-                        website = profile.website || "";
-                        // IG handle: prefer direct field, fall back to nested
-                        // social.instagram, then parse from a website URL.
-                        if (typeof profile.instagram === "string") {
-                            instagram = profile.instagram.trim();
-                        } else if (
-                            profile.social &&
-                            typeof profile.social.instagram === "string"
-                        ) {
-                            instagram = profile.social.instagram.trim();
-                        } else if (typeof profile.website === "string") {
-                            const m = profile.website.match(/instagram\.com\/([A-Za-z0-9._]+)/);
-                            if (m) instagram = m[1];
-                        }
-                    } catch (err) {
-                        console.error("Failed to parse profile metadata", err);
-                    }
-                }
-
-                if (jsonMetadata) {
-                    try {
-                        const rawMetadata = JSON.parse(jsonMetadata);
-                        const parsedMetadata = migrateLegacyMetadata(rawMetadata);
-                        ethereum_address = parsedMetadata.extensions?.wallets?.primary_wallet || "";
-                        video_parts = parsedMetadata.extensions?.video_parts || [];
-                        const defaultWeight = parsedMetadata.extensions?.settings?.voteSettings?.default_voting_weight;
-                        vote_weight = typeof defaultWeight === 'number' ? Math.round(defaultWeight / 100) : 51;
-                        zineCover = parsedMetadata.extensions?.settings?.appSettings?.zineCover || "";
-                        svs_profile = parsedMetadata.extensions?.settings?.appSettings?.svs_profile || "";
-                    } catch (err) {
-                        console.error("Failed to parse json_metadata", err);
-                    }
-                }
-
-                setProfileData({
-                    profileImage,
-                    coverImage,
-                    website,
+                updateProfileData({
                     name: profileInfo?.metadata?.profile?.name || username,
                     followers: profileInfo?.stats?.followers || 0,
                     following: profileInfo?.stats?.following || 0,
                     location: profileInfo?.metadata?.profile?.location || "",
                     about: profileInfo?.metadata?.profile?.about || "",
-                    ethereum_address,
-                    video_parts,
-                    vote_weight,
                     vp_percent: powerInfo?.data?.vp_percent || "0%",
                     rc_percent: powerInfo?.data?.rc_percent || "0%",
-                    zineCover,
-                    svs_profile,
-                    instagram,
                 });
-
             } catch (err) {
-                console.error("Failed to fetch profile info", err);
+                console.error("Failed to fetch bridge profile info", err);
             }
-        };
-
-        fetchProfileInfo();
+        })();
     }, [username, hasHiveAccount, postingMetadata, jsonMetadata]);
 
     return { profileData, updateProfileData };

--- a/hooks/useProfileData.ts
+++ b/hooks/useProfileData.ts
@@ -44,7 +44,8 @@ export default function useProfileData(username: string, hiveAccount: HiveAccoun
 
     useEffect(() => {
         if (!username || !hasHiveAccount) return;
-        
+
+        let cancelled = false;
         let profileImage = "";
         let coverImage = "";
         let website = "";
@@ -95,7 +96,9 @@ export default function useProfileData(username: string, hiveAccount: HiveAccoun
             }
         }
 
-        updateProfileData({ name: username, profileImage, coverImage, website, instagram, ethereum_address, video_parts, vote_weight, zineCover, svs_profile });
+        // Reset bridge fields in the same call so stale follower counts from
+        // the previous username don't show while Phase 2 is in-flight.
+        updateProfileData({ name: username, profileImage, coverImage, website, instagram, ethereum_address, video_parts, vote_weight, zineCover, svs_profile, followers: 0, following: 0, location: "", about: "", vp_percent: "0%", rc_percent: "0%" });
 
         // --- Phase 2: bridge API (async, can fail independently) ---
         (async () => {
@@ -104,6 +107,7 @@ export default function useProfileData(username: string, hiveAccount: HiveAccoun
                 const profileInfo = await getProfile(username);
                 const powerInfo = await getAccountWithPower(username);
 
+                if (cancelled) return;
                 updateProfileData({
                     name: profileInfo?.metadata?.profile?.name || username,
                     followers: profileInfo?.stats?.followers || 0,
@@ -117,6 +121,8 @@ export default function useProfileData(username: string, hiveAccount: HiveAccoun
                 console.error("Failed to fetch bridge profile info", err);
             }
         })();
+
+        return () => { cancelled = true; };
     }, [username, hasHiveAccount, postingMetadata, jsonMetadata]);
 
     return { profileData, updateProfileData };


### PR DESCRIPTION
## What changed
Two independent bugs were found and fixed:

1. **hooks/useProfileData.ts** — profileImage extraction (local data, 
   no network needed) was inside the same try/catch as getProfile()/
   getAccountWithPower() (network calls). If those failed, profileImage 
   never got set, even though it never depended on the network.

2. **components/profile/ProfileHeader.tsx** — the memo comparator only 
   checked profileData.ethereum_address, never profileImage or 
   hiveProfileData. Even after fix #1 resolved profileImage correctly, 
   ProfileHeader would bail on re-render and never pass the new image down.

Both fixes were required — #1 alone wasn't enough because the memo 
comparator was silently blocking the update regardless.

## Tested
- sktbr (has profile_image) → avatar now displays correctly
- felixop (no profile_image) → fallback initial still displays correctly

## Acceptance criteria
- ✅ skatehive.app/user/sktbr no longer shows fallback S
- ✅ Avatar resolution checks Hive profile JSON before falling back
- ✅ profile.profile_image from sktbr metadata is supported
- ✅ Fallback initial avatar still used only when no valid avatar exists

Closes #132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Profile headers now refresh more reliably when profile images change.
* **Bug Fixes**
  * Profile details are populated in stages: basic information loads first, with additional account/bridge-derived data filled in shortly after.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->