### PR TITLE
feat(auth): multi-account Hive login (PeakD-style)

### DIFF
--- a/components/layout/AuthButton.tsx
+++ b/components/layout/AuthButton.tsx
@@ -38,7 +38,7 @@ interface ConnectionStatus {
 }
 
 export default function AuthButton() {
-  const { user, aioha } = useAioha();
+  const { user } = useAioha();
   const { user: userbaseUser } = useUserbaseAuth();
   const { colorMode } = useColorMode();
   const [modalDisplayed, setModalDisplayed] = useState(false);
@@ -285,10 +285,13 @@ export default function AuthButton() {
 
   // Connection handlers - Memoized with useCallback
   const handleHiveLogin = useCallback(async () => {
+    // Do NOT log out the current account here: aioha.login() preserves the
+    // previously active account as an "other login", so opening the login modal
+    // while already authenticated becomes "add another Hive account" (PeakD-style).
+    // When no session exists, this is just a regular first login.
     setIsConnectionModalOpen(false);
-    await aioha.logout();
     setModalDisplayed(true);
-  }, [aioha]);
+  }, []);
 
   const handleFarcasterConnect = useCallback(() => {
     if (isFarcasterAuthInProgress || isFarcasterConnected) return;

--- a/components/layout/ConnectionModal.tsx
+++ b/components/layout/ConnectionModal.tsx
@@ -9,6 +9,7 @@ import {
   useToast,
   Tooltip,
   Image,
+  Avatar,
   Box,
   Circle,
   Badge,
@@ -304,6 +305,9 @@ export default function ConnectionModal({
   // Multi-account (PeakD-style) handlers — operate on the aioha account axis.
   const handleSwitchUser = (username: string) => {
     if (username === user) return;
+    // switchUser only restores the local session; non-Keychain providers
+    // (HiveAuth/Ledger) may still require re-authentication on the next
+    // broadcast even when this returns true.
     const ok = aioha.switchUser(username);
     toast(
       ok
@@ -313,8 +317,14 @@ export default function ConnectionModal({
   };
 
   const handleRemoveOtherLogin = (username: string) => {
-    aioha.removeOtherLogin(username);
-    toast({ status: "info", title: `removed: ${username}` });
+    try {
+      // removeOtherLogin throws if the account is already gone (e.g. a double
+      // click, or an account_changed re-render landing between render and click).
+      aioha.removeOtherLogin(username);
+      toast({ status: "info", title: `removed: ${username}` });
+    } catch {
+      toast({ status: "error", title: `could not remove ${username}` });
+    }
   };
 
   const handleFarcasterDisconnect = async () => {
@@ -490,11 +500,11 @@ export default function ConnectionModal({
                             outlineOffset: "2px",
                           }}
                         >
-                          <Image
+                          <Avatar
                             src={`https://images.hive.blog/u/${account.username}/avatar/small`}
+                            name={account.username}
                             boxSize={8}
                             borderRadius="sm"
-                            alt=""
                             flexShrink={0}
                           />
                           <VStack align="start" spacing={0} flex={1} minW={0}>

--- a/components/layout/ConnectionModal.tsx
+++ b/components/layout/ConnectionModal.tsx
@@ -15,7 +15,7 @@ import {
   IconButton,
   Fade,
 } from "@chakra-ui/react";
-import { InfoOutlineIcon, ArrowBackIcon } from "@chakra-ui/icons";
+import { InfoOutlineIcon, ArrowBackIcon, SmallCloseIcon } from "@chakra-ui/icons";
 
 import { keyframes } from "@emotion/react";
 import SkateModal from "@/components/shared/SkateModal";
@@ -240,7 +240,7 @@ export default function ConnectionModal({
   actualFarcasterConnection,
 }: ConnectionModalProps) {
   const isMobile = useIsMobile();
-  const { user, aioha } = useAioha();
+  const { user, aioha, provider: activeProvider, otherUsers } = useAioha();
   const { user: userbaseUser, signOut: signOutUserbase } = useUserbaseAuth();
   const { disconnect: disconnectEth } = useDisconnect();
   const router = useRouter();
@@ -299,6 +299,22 @@ export default function ConnectionModal({
   const handleHiveLogout = async () => {
     await aioha.logout();
     toast({ status: "success", title: "disconnected: hive" });
+  };
+
+  // Multi-account (PeakD-style) handlers — operate on the aioha account axis.
+  const handleSwitchUser = (username: string) => {
+    if (username === user) return;
+    const ok = aioha.switchUser(username);
+    toast(
+      ok
+        ? { status: "success", title: `switched: ${username}` }
+        : { status: "error", title: `could not switch to ${username}` }
+    );
+  };
+
+  const handleRemoveOtherLogin = (username: string) => {
+    aioha.removeOtherLogin(username);
+    toast({ status: "info", title: `removed: ${username}` });
   };
 
   const handleFarcasterDisconnect = async () => {
@@ -405,6 +421,176 @@ export default function ConnectionModal({
                     PROFILE →
                   </Text>
                 </HStack>
+
+                {/* Hive accounts switcher (PeakD-style) — only when a Hive session is active */}
+                {user && (
+                  <Box pt={1}>
+                    <HStack spacing={2} mb={2} align="center">
+                      <Box flex={1} h="1px" bg="whiteAlpha.100" />
+                      <Text
+                        fontFamily="mono"
+                        fontSize="2xs"
+                        color="gray.600"
+                        textTransform="lowercase"
+                        flexShrink={0}
+                      >
+                        hive accounts
+                      </Text>
+                      <Box flex={1} h="1px" bg="whiteAlpha.100" />
+                    </HStack>
+                    <VStack spacing={1} align="stretch">
+                      {[
+                        { username: user, provider: activeProvider, active: true },
+                        ...Object.entries(otherUsers || {}).map(
+                          ([username, prov]) => ({
+                            username,
+                            provider: prov,
+                            active: false,
+                          })
+                        ),
+                      ].map((account) => (
+                        <HStack
+                          key={account.username}
+                          spacing={3}
+                          py={2}
+                          px={2}
+                          borderRadius="sm"
+                          border="1px solid"
+                          borderColor={account.active ? "primary" : "whiteAlpha.100"}
+                          bg={account.active ? "whiteAlpha.50" : "transparent"}
+                          cursor={account.active ? "default" : "pointer"}
+                          onClick={
+                            account.active
+                              ? undefined
+                              : () => handleSwitchUser(account.username)
+                          }
+                          role={account.active ? undefined : "button"}
+                          tabIndex={account.active ? undefined : 0}
+                          aria-label={
+                            account.active
+                              ? `${account.username} (active)`
+                              : `switch to ${account.username}`
+                          }
+                          onKeyDown={(e) => {
+                            if (
+                              !account.active &&
+                              (e.key === "Enter" || e.key === " ")
+                            )
+                              handleSwitchUser(account.username);
+                          }}
+                          transition="border-color 0.15s, background-color 0.15s"
+                          _hover={
+                            account.active
+                              ? undefined
+                              : { borderColor: "primary", bg: "whiteAlpha.50" }
+                          }
+                          _focusVisible={{
+                            outline: "2px solid",
+                            outlineColor: "primary",
+                            outlineOffset: "2px",
+                          }}
+                        >
+                          <Image
+                            src={`https://images.hive.blog/u/${account.username}/avatar/small`}
+                            boxSize={8}
+                            borderRadius="sm"
+                            alt=""
+                            flexShrink={0}
+                          />
+                          <VStack align="start" spacing={0} flex={1} minW={0}>
+                            <Text
+                              fontFamily="mono"
+                              fontSize="sm"
+                              color={account.active ? "primary" : "gray.300"}
+                              noOfLines={1}
+                            >
+                              @{account.username}
+                            </Text>
+                            {account.provider && (
+                              <Text
+                                fontFamily="mono"
+                                fontSize="2xs"
+                                color="gray.600"
+                                textTransform="lowercase"
+                              >
+                                {account.provider}
+                              </Text>
+                            )}
+                          </VStack>
+
+                          {account.active ? (
+                            <HStack
+                              spacing={1.5}
+                              px={2}
+                              py={0.5}
+                              borderRadius="sm"
+                              border="1px solid"
+                              borderColor="primary"
+                              bg="whiteAlpha.100"
+                              flexShrink={0}
+                            >
+                              <Circle
+                                size="6px"
+                                bg="primary"
+                                boxShadow="0 0 4px var(--chakra-colors-primary)"
+                                animation={`${pulse} 2s ease-in-out infinite`}
+                              />
+                              <Text
+                                fontSize="2xs"
+                                fontFamily="mono"
+                                color="primary"
+                                lineHeight={1}
+                              >
+                                active
+                              </Text>
+                            </HStack>
+                          ) : (
+                            <HStack spacing={1} flexShrink={0}>
+                              <Text
+                                fontFamily="mono"
+                                fontSize="2xs"
+                                color="gray.500"
+                              >
+                                switch
+                              </Text>
+                              <Tooltip label="remove account" placement="top" hasArrow>
+                                <IconButton
+                                  aria-label={`remove ${account.username}`}
+                                  icon={<SmallCloseIcon />}
+                                  size="xs"
+                                  variant="ghost"
+                                  color="gray.600"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    handleRemoveOtherLogin(account.username);
+                                  }}
+                                  _hover={{ color: "red.400", bg: "whiteAlpha.100" }}
+                                />
+                              </Tooltip>
+                            </HStack>
+                          )}
+                        </HStack>
+                      ))}
+
+                      {/* Add another Hive account */}
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        fontFamily="mono"
+                        color="gray.400"
+                        justifyContent="flex-start"
+                        leftIcon={<Icon as={FaHive} boxSize={3} color="red.400" />}
+                        border="1px dashed"
+                        borderColor="whiteAlpha.200"
+                        py={4}
+                        onClick={onHiveLogin}
+                        _hover={{ color: "primary", borderColor: "primary", bg: "whiteAlpha.50" }}
+                      >
+                        + add hive account
+                      </Button>
+                    </VStack>
+                  </Box>
+                )}
 
                 {/* Linking prompt - show when there are unlinked opportunities */}
                 {hasUnlinkedOpportunities && !isLoading && (


### PR DESCRIPTION
## What & why

Adds **multi-account Hive login (PeakD-style)**: users can add, switch between, and remove multiple Hive accounts within the same browser session, see which one is active, and sign out without losing the others.

The heavy lifting already exists in the `@aioha/aioha` library (`switchUser` / `getOtherLogins` / `removeOtherLogin`), and `login()` already preserves the previously active account as an "other login". So this is mostly UI + wiring — **no backend, schema, env or dependency changes**.

## Changes

- **`AuthButton`** — stop force-logging-out before opening the Hive login modal. Because `login()` keeps the prior account, opening the login while authenticated now **adds** an account instead of replacing it (first login is unchanged).
- **`ConnectionModal`** — new "hive accounts" section in the session view:
  - lists the active account + other logins
  - click an inactive account → `switchUser`
  - `x` → `removeOtherLogin` (wrapped in try/catch — it throws on a double click / mid-render `account_changed`)
  - "+ add hive account" → opens the existing Hive login modal
  - account avatars use Chakra `Avatar` with an initials fallback
  - reuses the existing terminal-style badges / `ConnectionStatus`

Voting/commenting route through `aioha` directly, so switching the active account reroutes signing automatically.

## Acceptance criteria

- [x] Add more than one Hive account to the same session
- [x] Switch between saved accounts from the authenticated UI
- [x] Active account clearly indicated after switching
- [x] Existing single-account login still works
- [x] Logging out removes/disables the active session (END SESSION / hive row), `x` removes inactive accounts

## How to test

1. Log in with Hive account A (Keychain) → ConnectionModal shows A as `active`.
2. Open the modal → **+ add hive account** → log in with account B. A is kept as a switchable account (not logged out).
3. Click A in the list → it becomes active; the AuthButton avatar/name updates; a like/comment is signed by A.
4. Reload → both accounts persist (aioha `loadAuth()`), active one restored.
5. `x` removes an inactive account; **END SESSION** logs out the active one.

> Note: if Keychain shows "Failed to fetch" / "Hive Engine node is not replying" while testing, that's Keychain's own RPC node config (Skatehive doesn't override the node like PeakD does), not this change — pin a working Hive / Hive-Engine RPC node in Keychain settings.

## Notes for reviewer (re: automated review nits)

A few items are intentionally left as-is for consistency with the file:
- **No `useMemo` for the accounts list** — it's a cold path (a modal), the array is trivial to rebuild.
- **Hardcoded strings** ("switch", "active"…) — the whole modal already uses fixed terminal-style text ("session", "available connections"…).
- **Handlers not `useCallback`-wrapped** — existing handlers in this file (`handleHiveLogout`, `handleFarcasterDisconnect`) aren't either.
- **Active account also appears in the "available connections" hive row** — that row is connection status; the new section is account management.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
