### PR TITLE
fix(userbase): mask soft-post replies (overlay context-miss fallback)

### DIFF
--- a/hooks/useSoftPostOverlay.ts
+++ b/hooks/useSoftPostOverlay.ts
@@ -260,21 +260,30 @@ export default function useSoftPostOverlay(
   const normalizedPermlink = permlink?.trim();
   const key = getKey(normalizedAuthor, normalizedPermlink);
 
-  // Memoize the posts array to prevent unnecessary re-renders and race conditions
-  const posts = useMemo(() => {
-    // Skip building posts array when context provides data
-    if (context) return [];
-    if (!normalizedAuthor || !normalizedPermlink) return [];
-    return [{ author: normalizedAuthor, permlink: normalizedPermlink, safe_user: safeUser }];
-  }, [context, normalizedAuthor, normalizedPermlink, safeUser]);
+  // What the batch provider (if any) already knows for this post.
+  const contextHit =
+    context && normalizedAuthor && normalizedPermlink
+      ? context.getPost(normalizedAuthor, normalizedPermlink)
+      : null;
 
-  // This triggers the fetch only when there's no context provider
+  // Memoize the posts array to prevent unnecessary re-renders and race conditions.
+  const posts = useMemo(() => {
+    if (!normalizedAuthor || !normalizedPermlink) return [];
+    // Already resolved by the batch provider — no individual fetch needed.
+    if (contextHit) return [];
+    // Context MISS: the SoftPostProvider only batches top-level feed items, so
+    // replies (and anything else not in the batch) fall through here. Only worth
+    // an individual fetch when this looks like a shared-account soft post — those
+    // carry skatehive_user in their json_metadata (-> safeUser) — so normal
+    // replies don't each trigger a request.
+    if (context && !safeUser) return [];
+    return [{ author: normalizedAuthor, permlink: normalizedPermlink, safe_user: safeUser }];
+  }, [context, contextHit, normalizedAuthor, normalizedPermlink, safeUser]);
+
+  // Triggers a fetch when there's no provider, or on a context miss for a
+  // soft-post candidate (replies).
   const overlays = useSoftPostOverlays(posts);
 
-  // Prefer batch context if available
-  if (context && normalizedAuthor && normalizedPermlink) {
-    return context.getPost(normalizedAuthor, normalizedPermlink);
-  }
-
+  if (contextHit) return contextHit;
   return key ? overlays[key] ?? null : null;
 }


### PR DESCRIPTION
## Bug
A lite user's comment posted via @skateuser rendered as **skateuser** even after refresh — the soft-post overlay never applied to replies.

## Root cause (pre-existing)
`useSoftPostOverlay` (single) skipped its individual fetch whenever a `SoftPostProvider` was present and just read `context.getPost`. But the provider only batches **top-level feed items** (`filteredAndSortedComments`), not replies — so reply lookups missed and there was no fallback. Never surfaced before because comment-type soft_posts effectively didn't exist until the Phase 2 comment cutover started creating them.

## Fix
On a context **miss**, fall back to an individual (cached) fetch — gated on `safeUser` (the on-chain `skatehive_user` tag) so only shared-account soft-post candidates trigger a request, not every normal reply.

## Verify
Refresh the feed: a lite-user comment via @skateuser now shows the real user (handle/avatar), not skateuser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how soft post overlays are loaded, so content now appears more reliably when context data is partially available.
  * Fixed a case where overlays could be skipped even though related context existed, reducing missing or delayed overlay content.
  * Added smarter fallback handling to choose the best available overlay source when direct context data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->