### PR TITLE
perf(web): ISR on collection pages + edge vote/comment proxies

### DIFF
--- a/app/api/userbase/hive/comment/route.ts
+++ b/app/api/userbase/hive/comment/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { proxyUserbaseHive } from "@/lib/userbase/proxyToApi";
 
-export const runtime = "nodejs";
+export const runtime = "edge";
 
 // Proxied to api.skatehive.app — the single owner of the comment broadcast +
 // soft-post (Phase 2 userbase unification). The full body (parent_author/permlink,

--- a/app/api/userbase/hive/vote/route.ts
+++ b/app/api/userbase/hive/vote/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { proxyUserbaseHive } from "@/lib/userbase/proxyToApi";
 
-export const runtime = "nodejs";
+export const runtime = "edge";
 
 // Proxied to api.skatehive.app — the single owner of the vote broadcast +
 // soft-vote attribution (Phase 2 userbase unification). The web client keeps

--- a/app/auction/page.tsx
+++ b/app/auction/page.tsx
@@ -82,6 +82,8 @@ export async function generateMetadata(): Promise<Metadata> {
   }
 }
 
+export const revalidate = 300; // ISR: render once, refresh every 5 min (static-safe page)
+
 export default function MainAuctionPage() {
   return <AuctionPage showNavigation={true} />;
 }

--- a/app/bounties/page.tsx
+++ b/app/bounties/page.tsx
@@ -66,6 +66,8 @@ export const metadata: Metadata = {
   },
 };
 
+export const revalidate = 300; // ISR: render once, refresh every 5 min (static-safe page)
+
 export default function BountiesPage() {
   return <BountiesHubClient />;
 }

--- a/app/cinema/page.tsx
+++ b/app/cinema/page.tsx
@@ -54,6 +54,8 @@ export const metadata: Metadata = {
   alternates: { canonical: `${BASE_URL}/cinema` },
 };
 
+export const revalidate = 300; // ISR: render once, refresh every 5 min (static-safe page)
+
 export default function CinemaPage() {
   const jsonLd = {
     "@context": "https://schema.org",

--- a/app/dao/page.tsx
+++ b/app/dao/page.tsx
@@ -32,6 +32,8 @@ export const metadata: Metadata = {
   },
 };
 
+export const revalidate = 300; // ISR: render once, refresh every 5 min (static-safe page)
+
 export default function DAOPage() {
   return <DAOPageClient />;
 }

--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -190,6 +190,8 @@ function GamesJsonLd() {
   );
 }
 
+export const revalidate = 300; // ISR: render once, refresh every 5 min (static-safe page)
+
 export default function GamesPage() {
   return (
     <>

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -144,6 +144,8 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
+export const revalidate = 300; // ISR: render once, refresh every 5 min (static-safe page)
+
 export default async function LeaderboardPage() {
   const { data: skatersData } = await processLeaderboardData(60); // 1 minute cache for page data
 

--- a/app/skaters/page.tsx
+++ b/app/skaters/page.tsx
@@ -64,6 +64,8 @@ export const metadata: Metadata = {
   },
 };
 
+export const revalidate = 300; // ISR: render once, refresh every 5 min (static-safe page)
+
 export default function SkatersPage() {
   const jsonLd = {
     "@context": "https://schema.org",

--- a/app/skateshops/page.tsx
+++ b/app/skateshops/page.tsx
@@ -66,6 +66,8 @@ export const metadata: Metadata = {
   },
 };
 
+export const revalidate = 300; // ISR: render once, refresh every 5 min (static-safe page)
+
 export default function SkateshopsPage() {
   const jsonLd = {
     "@context": "https://schema.org",

--- a/app/tricks/page.tsx
+++ b/app/tricks/page.tsx
@@ -144,6 +144,8 @@ async function fetchPostsForTrick(tags: string[]): Promise<number> {
     }
 }
 
+export const revalidate = 300; // ISR: render once, refresh every 5 min (static-safe page)
+
 export default async function TricksPage() {
     const jsonLd = {
         "@context": "https://schema.org",


### PR DESCRIPTION
ISR (revalidate=300) on 9 static server pages (verified: no cookies/headers/searchParams) + edge runtime for the vote/comment fetch-forwarders. Cuts per-request SSR + cold-starts. 🤖 Generated with [Claude Code](https://claude.com/claude-code)