### PR TITLE
fix: preserve YouTube Shorts rendering in post embeds

### DIFF
--- a/components/shared/HiveMarkdown.tsx
+++ b/components/shared/HiveMarkdown.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo } from "react";
 import markdownRenderer from "@/lib/markdown/MarkdownRenderer";
+import { getYouTubePlaceholder } from "@/lib/markdown/MarkdownRenderer";
 import SkateErrorBoundary from "./SkateErrorBoundary";
 import { Skeleton } from "@chakra-ui/react";
 import { observeHeicImages } from "@/lib/utils/heicImageFallback";
@@ -84,12 +85,12 @@ const HiveMarkdown: React.FC<HiveMarkdownProps> = ({
         // mount the YouTubeLite component (high-res poster + click-to-play).
         const processYouTubeEmbeds = (html: string) => {
           let out = html.replace(
-            /<div class=["']videoWrapper["'][^>]*>\s*<iframe[^>]*src=["'](?:https?:)?\/\/(?:www\.)?(?:youtube(?:-nocookie)?\.com\/embed\/|youtu\.be\/)([a-zA-Z0-9_-]{11})[^"']*["'][^>]*><\/iframe>\s*<\/div>/gi,
-            (_m, videoId) => `[[YOUTUBE:${videoId}]]`
+            /<div class=["']videoWrapper["'][^>]*>\s*<iframe[^>]*src=["']([^"']+)["'][^>]*><\/iframe>\s*<\/div>/gi,
+            (match, src) => getYouTubePlaceholder(src) ?? match
           );
           out = out.replace(
-            /<iframe[^>]*src=["'](?:https?:)?\/\/(?:www\.)?(?:youtube(?:-nocookie)?\.com\/embed\/|youtu\.be\/)([a-zA-Z0-9_-]{11})[^"']*["'][^>]*><\/iframe>/gi,
-            (_m, videoId) => `[[YOUTUBE:${videoId}]]`
+            /<iframe[^>]*src=["']([^"']+)["'][^>]*><\/iframe>/gi,
+            (match, src) => getYouTubePlaceholder(src) ?? match
           );
           return out;
         };

--- a/lib/markdown/MarkdownRenderer.ts
+++ b/lib/markdown/MarkdownRenderer.ts
@@ -24,7 +24,7 @@ const YOUTUBE_URL_PATTERN = new RegExp(
     "i"
 );
 
-function getYouTubePlaceholder(rawUrl: string): string | null {
+export function getYouTubePlaceholder(rawUrl: string): string | null {
     const normalizedUrl = rawUrl.trim().replace(/^<|>$/g, "");
     try {
         const url = new URL(normalizedUrl);

--- a/lib/markdown/__tests__/MarkdownRenderer.test.ts
+++ b/lib/markdown/__tests__/MarkdownRenderer.test.ts
@@ -78,6 +78,15 @@ describe("processMediaContent YouTube autoembed", () => {
 
     assertIncludes(result, "[[YOUTUBE:s:dQw4w9WgXcQ]]");
   });
+
+  it("keeps markdown-linked shorts tagged for vertical rendering", () => {
+    const result = processMediaContent(
+      "[short](https://www.youtube.com/shorts/dQw4w9WgXcQ?feature=share)"
+    );
+
+    assertIncludes(result, "[[YOUTUBE:s:dQw4w9WgXcQ]]");
+    assertNotIncludes(result, "[short]");
+  });
 });
 
 Promise.all(tests.map((test) => test())).then(() => {


### PR DESCRIPTION
## Summary
- preserve the Shorts marker when normalizing YouTube embeds back into SkateHive placeholders
- reuse the shared YouTube placeholder parser in HiveMarkdown so Shorts do not get downgraded to 16:9 embeds
- add coverage for markdown-linked Shorts URLs

## Testing
- pnpm test
- pnpm lint
- pnpm build

## Notes
- I could not attach a local screenshot from this isolated checkout because the sample post route was returning HTTP 500 locally in this environment, but the markdown pipeline fix and repo checks passed.

Closes #142


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YouTube embed handling in markdown content, including support for additional embed formats and YouTube Shorts links.
  * Embedded videos now render more consistently, with fallback behavior when a preview placeholder can’t be generated.

* **Tests**
  * Added coverage for YouTube auto-embed behavior to verify Shorts links are converted correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->