### PR TITLE
fix(#91): profile header data not loading on initial load + follow counter lag

### DIFF
--- a/components/profile/FollowButton.tsx
+++ b/components/profile/FollowButton.tsx
@@ -15,6 +15,8 @@ interface FollowButtonProps {
   isLiteUser?: boolean;
   /** If true, broadcast follow through the server with the DB-stored posting key */
   useStoredPostingKey?: boolean;
+  /** Called after a follow/unfollow is confirmed so the parent can refresh follower counts */
+  onFollowConfirmed?: () => void;
 }
 
 export default function FollowButton({
@@ -26,6 +28,7 @@ export default function FollowButton({
   onLoadingChange,
   isLiteUser = false,
   useStoredPostingKey = false,
+  onFollowConfirmed,
 }: FollowButtonProps) {
   const toast = useToast();
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
@@ -57,6 +60,7 @@ export default function FollowButton({
         }
         onFollowingChange(Boolean(data?.isFollowing));
         onLoadingChange(false);
+        onFollowConfirmed?.();
         return;
       }
 
@@ -70,6 +74,7 @@ export default function FollowButton({
         if (backendState === next) {
           onFollowingChange(next);
           onLoadingChange(false);
+          onFollowConfirmed?.();
         } else if (tries < maxTries) {
           setTimeout(poll, 1000);
         } else {
@@ -109,6 +114,7 @@ export default function FollowButton({
     toast,
     isLiteUser,
     useStoredPostingKey,
+    onFollowConfirmed,
   ]);
 
   // Show button for lite users (to trigger upgrade modal) or for logged in users

--- a/components/profile/FollowButton.tsx
+++ b/components/profile/FollowButton.tsx
@@ -58,7 +58,11 @@ export default function FollowButton({
         if (!response.ok) {
           throw new Error(data?.error || "Failed to update follow status");
         }
-        const confirmedFollowing = Boolean(data?.isFollowing);
+        // Trust the server's explicit boolean when present; fall back to `next`
+        // (the action that was actually performed) when the upstream doesn't
+        // return isFollowing (e.g. a raw Hive broadcast result).
+        const confirmedFollowing =
+          typeof data?.isFollowing === "boolean" ? data.isFollowing : next;
         onFollowingChange(confirmedFollowing);
         onLoadingChange(false);
         onFollowConfirmed?.(confirmedFollowing ? +1 : -1);

--- a/components/profile/FollowButton.tsx
+++ b/components/profile/FollowButton.tsx
@@ -15,8 +15,8 @@ interface FollowButtonProps {
   isLiteUser?: boolean;
   /** If true, broadcast follow through the server with the DB-stored posting key */
   useStoredPostingKey?: boolean;
-  /** Called after a follow/unfollow is confirmed so the parent can refresh follower counts */
-  onFollowConfirmed?: () => void;
+  /** Called after a follow/unfollow is confirmed with the follower-count delta (+1 or -1) */
+  onFollowConfirmed?: (delta: number) => void;
 }
 
 export default function FollowButton({
@@ -58,9 +58,10 @@ export default function FollowButton({
         if (!response.ok) {
           throw new Error(data?.error || "Failed to update follow status");
         }
-        onFollowingChange(Boolean(data?.isFollowing));
+        const confirmedFollowing = Boolean(data?.isFollowing);
+        onFollowingChange(confirmedFollowing);
         onLoadingChange(false);
-        onFollowConfirmed?.();
+        onFollowConfirmed?.(confirmedFollowing ? +1 : -1);
         return;
       }
 
@@ -74,7 +75,7 @@ export default function FollowButton({
         if (backendState === next) {
           onFollowingChange(next);
           onLoadingChange(false);
-          onFollowConfirmed?.();
+          onFollowConfirmed?.(next ? +1 : -1);
         } else if (tries < maxTries) {
           setTimeout(poll, 1000);
         } else {

--- a/components/profile/HiveProfileHeader.tsx
+++ b/components/profile/HiveProfileHeader.tsx
@@ -24,6 +24,8 @@ interface HiveProfileHeaderProps {
   isLiteUser?: boolean;
   /** If true, follow actions can use the viewer DB-stored posting key */
   useStoredPostingKey?: boolean;
+  /** Called after follow/unfollow is confirmed so follower counts can be refreshed */
+  onFollowConfirmed?: () => void;
 }
 
 const HiveProfileHeader = function HiveProfileHeader({
@@ -40,6 +42,7 @@ const HiveProfileHeader = function HiveProfileHeader({
   integrations,
   isLiteUser = false,
   useStoredPostingKey = false,
+  onFollowConfirmed,
 }: HiveProfileHeaderProps) {
   // Fetch voting power value in dollars
   const [voteValue, setVoteValue] = useState<number | null>(null);
@@ -141,6 +144,7 @@ const HiveProfileHeader = function HiveProfileHeader({
         onLoadingChange={onLoadingChange}
         isLiteUser={isLiteUser && !useStoredPostingKey}
         useStoredPostingKey={useStoredPostingKey}
+        onFollowConfirmed={onFollowConfirmed}
       />
     ) : null;
 

--- a/components/profile/HiveProfileHeader.tsx
+++ b/components/profile/HiveProfileHeader.tsx
@@ -24,8 +24,8 @@ interface HiveProfileHeaderProps {
   isLiteUser?: boolean;
   /** If true, follow actions can use the viewer DB-stored posting key */
   useStoredPostingKey?: boolean;
-  /** Called after follow/unfollow is confirmed so follower counts can be refreshed */
-  onFollowConfirmed?: () => void;
+  /** Called after follow/unfollow is confirmed with the follower-count delta (+1 or -1) */
+  onFollowConfirmed?: (delta: number) => void;
 }
 
 const HiveProfileHeader = function HiveProfileHeader({

--- a/components/profile/MobileProfileHeader.tsx
+++ b/components/profile/MobileProfileHeader.tsx
@@ -105,7 +105,10 @@ const MobileProfileHeader = memo(function MobileProfileHeader({
         if (!response.ok) {
           throw new Error(data?.error || "Failed to update follow status");
         }
-        confirmedFollowing = Boolean(data?.isFollowing);
+        // Same guard as FollowButton: fall back to `next` when upstream
+        // doesn't return isFollowing (raw Hive broadcast result).
+        confirmedFollowing =
+          typeof data?.isFollowing === "boolean" ? data.isFollowing : next;
         onFollowingChange(confirmedFollowing);
       } else {
         await changeFollow(user, username);

--- a/components/profile/MobileProfileHeader.tsx
+++ b/components/profile/MobileProfileHeader.tsx
@@ -33,6 +33,8 @@ interface MobileProfileHeaderProps {
   isLiteUser?: boolean;
   /** If true, follow actions can use the viewer DB-stored posting key */
   useStoredPostingKey?: boolean;
+  /** Called after follow/unfollow is confirmed so follower counts can be refreshed */
+  onFollowConfirmed?: () => void;
 }
 
 const MobileProfileHeader = memo(function MobileProfileHeader({
@@ -48,6 +50,7 @@ const MobileProfileHeader = memo(function MobileProfileHeader({
   onEditModalOpen,
   isLiteUser = false,
   useStoredPostingKey = false,
+  onFollowConfirmed,
 }: MobileProfileHeaderProps) {
   const router = useRouter();
   const { aioha } = useAioha();
@@ -105,6 +108,7 @@ const MobileProfileHeader = memo(function MobileProfileHeader({
         // Keep optimistic state
       }
       onLoadingChange(false);
+      onFollowConfirmed?.();
     } catch (error) {
       console.error("Follow action failed:", error);
       // Revert on error
@@ -118,6 +122,7 @@ const MobileProfileHeader = memo(function MobileProfileHeader({
     isFollowLoading,
     onFollowingChange,
     onLoadingChange,
+    onFollowConfirmed,
     isLiteUser,
     useStoredPostingKey,
   ]);

--- a/components/profile/MobileProfileHeader.tsx
+++ b/components/profile/MobileProfileHeader.tsx
@@ -33,8 +33,8 @@ interface MobileProfileHeaderProps {
   isLiteUser?: boolean;
   /** If true, follow actions can use the viewer DB-stored posting key */
   useStoredPostingKey?: boolean;
-  /** Called after follow/unfollow is confirmed so follower counts can be refreshed */
-  onFollowConfirmed?: () => void;
+  /** Called after follow/unfollow is confirmed with the follower-count delta (+1 or -1) */
+  onFollowConfirmed?: (delta: number) => void;
 }
 
 const MobileProfileHeader = memo(function MobileProfileHeader({
@@ -91,6 +91,9 @@ const MobileProfileHeader = memo(function MobileProfileHeader({
     onFollowingChange(next);
     onLoadingChange(true);
 
+    // For the stored-key path, use the server-confirmed follow state.
+    // For the Keychain path, keep the optimistic `next` value.
+    let confirmedFollowing = next;
     try {
       if (useStoredPostingKey) {
         const response = await fetch("/api/userbase/hive/follow", {
@@ -102,13 +105,14 @@ const MobileProfileHeader = memo(function MobileProfileHeader({
         if (!response.ok) {
           throw new Error(data?.error || "Failed to update follow status");
         }
-        onFollowingChange(Boolean(data?.isFollowing));
+        confirmedFollowing = Boolean(data?.isFollowing);
+        onFollowingChange(confirmedFollowing);
       } else {
         await changeFollow(user, username);
         // Keep optimistic state
       }
       onLoadingChange(false);
-      onFollowConfirmed?.();
+      onFollowConfirmed?.(confirmedFollowing ? +1 : -1);
     } catch (error) {
       console.error("Follow action failed:", error);
       // Revert on error

--- a/components/profile/ProfileHeader.tsx
+++ b/components/profile/ProfileHeader.tsx
@@ -456,6 +456,15 @@ export default memo(ProfileHeader, (prevProps, nextProps) => {
       nextProps.profileData.ethereum_address &&
     prevProps.profileData.profileImage === nextProps.profileData.profileImage &&
     prevProps.hiveProfileData?.profileImage === nextProps.hiveProfileData?.profileImage &&
+    // Phase 2 bridge fields — written async by useProfileData after hiveAccount resolves.
+    // Without these, ProfileHeader's memo blocks re-renders when the bridge API
+    // returns, leaving follower counts, bio, name, and VP% stale.
+    prevProps.hiveProfileData?.followers === nextProps.hiveProfileData?.followers &&
+    prevProps.hiveProfileData?.following === nextProps.hiveProfileData?.following &&
+    prevProps.hiveProfileData?.name === nextProps.hiveProfileData?.name &&
+    prevProps.hiveProfileData?.about === nextProps.hiveProfileData?.about &&
+    prevProps.hiveProfileData?.vp_percent === nextProps.hiveProfileData?.vp_percent &&
+    prevProps.hiveProfileData?.location === nextProps.hiveProfileData?.location &&
     prevProps.isOwner === nextProps.isOwner &&
     prevProps.isUserbaseOwner === nextProps.isUserbaseOwner &&
     prevProps.user === nextProps.user &&

--- a/components/profile/ProfileHeader.tsx
+++ b/components/profile/ProfileHeader.tsx
@@ -63,6 +63,8 @@ interface ProfileHeaderProps {
   userbaseUserId?: string | null;
   viewerHiveUsername?: string | null;
   useStoredPostingKey?: boolean;
+  /** Called after follow/unfollow is confirmed so follower counts can be refreshed */
+  onFollowConfirmed?: () => void;
 }
 
 const ProfileHeader = function ProfileHeader({
@@ -88,6 +90,7 @@ const ProfileHeader = function ProfileHeader({
   userbaseUserId = null,
   viewerHiveUsername = null,
   useStoredPostingKey = false,
+  onFollowConfirmed,
 }: ProfileHeaderProps) {
   useProfileDebug("ProfileHeader");
   const { connections } = useLinkedIdentities();
@@ -370,6 +373,7 @@ const ProfileHeader = function ProfileHeader({
         onEditModalOpen={activeEditHandler}
         isLiteUser={isViewerLiteUser}
         useStoredPostingKey={useStoredPostingKey}
+        onFollowConfirmed={onFollowConfirmed}
       />
 
       {/* Desktop Layout */}
@@ -420,6 +424,7 @@ const ProfileHeader = function ProfileHeader({
                 integrations={networkButtons}
                 isLiteUser={isViewerLiteUser}
                 useStoredPostingKey={useStoredPostingKey}
+                onFollowConfirmed={onFollowConfirmed}
               />
             </Box>
           )}
@@ -470,6 +475,7 @@ export default memo(ProfileHeader, (prevProps, nextProps) => {
     prevProps.farcasterProfile?.custody ===
       nextProps.farcasterProfile?.custody &&
     prevProps.farcasterProfile?.verifications ===
-      nextProps.farcasterProfile?.verifications
+      nextProps.farcasterProfile?.verifications &&
+    prevProps.onFollowConfirmed === nextProps.onFollowConfirmed
   );
 });

--- a/components/profile/ProfileHeader.tsx
+++ b/components/profile/ProfileHeader.tsx
@@ -63,8 +63,8 @@ interface ProfileHeaderProps {
   userbaseUserId?: string | null;
   viewerHiveUsername?: string | null;
   useStoredPostingKey?: boolean;
-  /** Called after follow/unfollow is confirmed so follower counts can be refreshed */
-  onFollowConfirmed?: () => void;
+  /** Called after follow/unfollow is confirmed with the follower-count delta (+1 or -1) */
+  onFollowConfirmed?: (delta: number) => void;
 }
 
 const ProfileHeader = function ProfileHeader({

--- a/components/profile/ProfilePage.tsx
+++ b/components/profile/ProfilePage.tsx
@@ -506,7 +506,7 @@ const ProfilePage = memo(function ProfilePage({ username }: ProfilePageProps) {
   >(null);
 
   // Custom hooks
-  const { profileData, updateProfileData } = useProfileData(
+  const { profileData, updateProfileData, refetchBridgeData } = useProfileData(
     hiveLookupHandle,
     hiveAccount
   );
@@ -893,6 +893,7 @@ const ProfilePage = memo(function ProfilePage({ username }: ProfilePageProps) {
               debugPayload={debugPayloadRef.current}
               hasHiveProfile={isHiveProfile || !!hiveIdentityHandle}
               hasUserbaseProfile={!!userbaseUser}
+              onFollowConfirmed={refetchBridgeData}
               farcasterProfile={farcasterProfileData}
               userbaseUserId={userbaseUser?.id}
             />

--- a/components/profile/ProfilePage.tsx
+++ b/components/profile/ProfilePage.tsx
@@ -506,7 +506,7 @@ const ProfilePage = memo(function ProfilePage({ username }: ProfilePageProps) {
   >(null);
 
   // Custom hooks
-  const { profileData, updateProfileData, refetchBridgeData } = useProfileData(
+  const { profileData, updateProfileData, refetchBridgeData, adjustFollowerCount } = useProfileData(
     hiveLookupHandle,
     hiveAccount
   );
@@ -893,7 +893,7 @@ const ProfilePage = memo(function ProfilePage({ username }: ProfilePageProps) {
               debugPayload={debugPayloadRef.current}
               hasHiveProfile={isHiveProfile || !!hiveIdentityHandle}
               hasUserbaseProfile={!!userbaseUser}
-              onFollowConfirmed={refetchBridgeData}
+              onFollowConfirmed={adjustFollowerCount}
               farcasterProfile={farcasterProfileData}
               userbaseUserId={userbaseUser?.id}
             />

--- a/hooks/useProfileData.ts
+++ b/hooks/useProfileData.ts
@@ -135,8 +135,8 @@ export default function useProfileData(username: string, hiveAccount: HiveAccoun
         return () => { cancelled = true; };
     }, [username, hasHiveAccount, postingMetadata, jsonMetadata]);
 
-    // Re-runs Phase 2 on demand (e.g. after follow/unfollow) so the displayed
-    // follower/following counts reflect the latest blockchain state.
+    // Re-runs Phase 2 on demand (manual reconciliation — not called after follow
+    // actions, which use adjustFollowerCount for an immediate optimistic update).
     const refetchBridgeData = useCallback(async () => {
         if (!username || !hasHiveAccount) return;
         try {
@@ -156,5 +156,19 @@ export default function useProfileData(username: string, hiveAccount: HiveAccoun
         }
     }, [username, hasHiveAccount, updateProfileData]);
 
-    return { profileData, updateProfileData, refetchBridgeData };
+    // Applies a +1/-1 follower count delta immediately after a confirmed
+    // follow/unfollow, without waiting for the bridge API (which has indexing
+    // lag and would return the pre-action count for several seconds).
+    // The currentUsernameRef guard prevents a stale in-flight confirmation
+    // (user navigated to a different profile mid-action) from landing on the
+    // wrong profile's count.
+    const adjustFollowerCount = useCallback((delta: number) => {
+        if (currentUsernameRef.current !== username) return;
+        setProfileData((prev) => ({
+            ...prev,
+            followers: Math.max(0, prev.followers + delta),
+        }));
+    }, [username]);
+
+    return { profileData, updateProfileData, refetchBridgeData, adjustFollowerCount };
 }

--- a/hooks/useProfileData.ts
+++ b/hooks/useProfileData.ts
@@ -131,5 +131,26 @@ export default function useProfileData(username: string, hiveAccount: HiveAccoun
         return () => { cancelled = true; };
     }, [username, hasHiveAccount, postingMetadata, jsonMetadata]);
 
-    return { profileData, updateProfileData };
+    // Re-runs Phase 2 on demand (e.g. after follow/unfollow) so the displayed
+    // follower/following counts reflect the latest blockchain state.
+    const refetchBridgeData = useCallback(async () => {
+        if (!username || !hasHiveAccount) return;
+        try {
+            const profileInfo = await getProfile(username);
+            const powerInfo = await getAccountWithPower(username);
+            updateProfileData({
+                name: profileInfo?.metadata?.profile?.name || username,
+                followers: profileInfo?.stats?.followers || 0,
+                following: profileInfo?.stats?.following || 0,
+                location: profileInfo?.metadata?.profile?.location || "",
+                about: profileInfo?.metadata?.profile?.about || "",
+                vp_percent: powerInfo?.data?.vp_percent || "0%",
+                rc_percent: powerInfo?.data?.rc_percent || "0%",
+            });
+        } catch (err) {
+            console.error("Failed to refetch bridge profile info", err);
+        }
+    }, [username, hasHiveAccount, updateProfileData]);
+
+    return { profileData, updateProfileData, refetchBridgeData };
 }

--- a/hooks/useProfileData.ts
+++ b/hooks/useProfileData.ts
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { getProfile, getAccountWithPower } from "@/lib/hive/client-functions";
 import type { ProfileData } from "../components/profile/ProfilePage";
 import { VideoPart } from "@/types/VideoPart";
@@ -42,9 +42,15 @@ export default function useProfileData(username: string, hiveAccount: HiveAccoun
         setProfileData((prev: ProfileData) => ({ ...prev, ...newData }));
     }, []);
 
+    // Tracks the username that the most-recently-started Phase 2 fetch belongs to.
+    // Updated synchronously at the start of each effect run so any in-flight IIFE
+    // from a previous username can detect it is stale before calling setState.
+    const currentUsernameRef = useRef(username);
+
     useEffect(() => {
         if (!username || !hasHiveAccount) return;
 
+        currentUsernameRef.current = username;
         let cancelled = false;
         let profileImage = "";
         let coverImage = "";
@@ -107,7 +113,7 @@ export default function useProfileData(username: string, hiveAccount: HiveAccoun
                 const profileInfo = await getProfile(username);
                 const powerInfo = await getAccountWithPower(username);
 
-                if (cancelled) return;
+                if (cancelled || currentUsernameRef.current !== username) return;
                 updateProfileData({
                     name: profileInfo?.metadata?.profile?.name || username,
                     followers: profileInfo?.stats?.followers || 0,

--- a/hooks/useProfileData.ts
+++ b/hooks/useProfileData.ts
@@ -114,12 +114,16 @@ export default function useProfileData(username: string, hiveAccount: HiveAccoun
                 const powerInfo = await getAccountWithPower(username);
 
                 if (cancelled || currentUsernameRef.current !== username) return;
+                if (!profileInfo) {
+                    console.warn(`Bridge profile fetch failed after retries for ${username}`);
+                    return;
+                }
                 updateProfileData({
-                    name: profileInfo?.metadata?.profile?.name || username,
-                    followers: profileInfo?.stats?.followers || 0,
-                    following: profileInfo?.stats?.following || 0,
-                    location: profileInfo?.metadata?.profile?.location || "",
-                    about: profileInfo?.metadata?.profile?.about || "",
+                    name: profileInfo.metadata?.profile?.name || username,
+                    followers: profileInfo.stats?.followers || 0,
+                    following: profileInfo.stats?.following || 0,
+                    location: profileInfo.metadata?.profile?.location || "",
+                    about: profileInfo.metadata?.profile?.about || "",
                     vp_percent: powerInfo?.data?.vp_percent || "0%",
                     rc_percent: powerInfo?.data?.rc_percent || "0%",
                 });

--- a/hooks/useProfileData.ts
+++ b/hooks/useProfileData.ts
@@ -47,10 +47,22 @@ export default function useProfileData(username: string, hiveAccount: HiveAccoun
     // from a previous username can detect it is stale before calling setState.
     const currentUsernameRef = useRef(username);
 
-    useEffect(() => {
-        if (!username || !hasHiveAccount) return;
+    // Tracks the last follower count the bridge successfully returned, keyed by
+    // username. Prevents a lagging bridge refetch from overwriting a locally-
+    // confirmed adjustFollowerCount delta. Stored as {username, count} so that
+    // navigating between profiles resets the baseline naturally — a stored baseline
+    // for "alice" is ignored when the current fetch is for "bob", treating it as a
+    // first fetch and accepting the bridge value.
+    const bridgeFollowersBaselineRef = useRef<{ username: string; count: number } | null>(null);
 
+    useEffect(() => {
+        // Must run unconditionally before any early return so that
+        // adjustFollowerCount's guard (currentUsernameRef.current !== username)
+        // always reflects the current render's username, even when we skip the
+        // fetch because hiveAccount isn't loaded yet.
         currentUsernameRef.current = username;
+
+        if (!username || !hasHiveAccount) return;
         let cancelled = false;
         let profileImage = "";
         let coverImage = "";
@@ -114,19 +126,38 @@ export default function useProfileData(username: string, hiveAccount: HiveAccoun
                 const powerInfo = await getAccountWithPower(username);
 
                 if (cancelled || currentUsernameRef.current !== username) return;
+                // Apply whichever fetches succeeded independently — a failed
+                // bridge profile shouldn't suppress a successful power query.
                 if (!profileInfo) {
                     console.warn(`Bridge profile fetch failed after retries for ${username}`);
-                    return;
+                } else {
+                    updateProfileData({
+                        name: profileInfo.metadata?.profile?.name || username,
+                        following: profileInfo.stats?.following || 0,
+                        location: profileInfo.metadata?.profile?.location || "",
+                        about: profileInfo.metadata?.profile?.about || "",
+                    });
+                    // Write followers only when the bridge has a genuinely new value —
+                    // if it returns the same count as the last accepted baseline the
+                    // indexer hasn't caught up yet, so we leave any local
+                    // adjustFollowerCount delta untouched.
+                    const bridgeCount = profileInfo.stats?.followers ?? 0;
+                    const baseline = bridgeFollowersBaselineRef.current;
+                    if (
+                        baseline === null ||
+                        baseline.username !== username ||
+                        bridgeCount !== baseline.count
+                    ) {
+                        bridgeFollowersBaselineRef.current = { username, count: bridgeCount };
+                        updateProfileData({ followers: bridgeCount });
+                    }
                 }
-                updateProfileData({
-                    name: profileInfo.metadata?.profile?.name || username,
-                    followers: profileInfo.stats?.followers || 0,
-                    following: profileInfo.stats?.following || 0,
-                    location: profileInfo.metadata?.profile?.location || "",
-                    about: profileInfo.metadata?.profile?.about || "",
-                    vp_percent: powerInfo?.data?.vp_percent || "0%",
-                    rc_percent: powerInfo?.data?.rc_percent || "0%",
-                });
+                if (powerInfo?.data) {
+                    updateProfileData({
+                        vp_percent: powerInfo.data.vp_percent || "0%",
+                        rc_percent: powerInfo.data.rc_percent || "0%",
+                    });
+                }
             } catch (err) {
                 console.error("Failed to fetch bridge profile info", err);
             }
@@ -137,20 +168,39 @@ export default function useProfileData(username: string, hiveAccount: HiveAccoun
 
     // Re-runs Phase 2 on demand (manual reconciliation — not called after follow
     // actions, which use adjustFollowerCount for an immediate optimistic update).
+    // Applies the same baseline guard and profileInfo/powerInfo decoupling as the
+    // Phase 2 effect IIFE so a manual refetch also can't clobber a local delta.
     const refetchBridgeData = useCallback(async () => {
         if (!username || !hasHiveAccount) return;
+        const requestUsername = username;
         try {
-            const profileInfo = await getProfile(username);
-            const powerInfo = await getAccountWithPower(username);
-            updateProfileData({
-                name: profileInfo?.metadata?.profile?.name || username,
-                followers: profileInfo?.stats?.followers || 0,
-                following: profileInfo?.stats?.following || 0,
-                location: profileInfo?.metadata?.profile?.location || "",
-                about: profileInfo?.metadata?.profile?.about || "",
-                vp_percent: powerInfo?.data?.vp_percent || "0%",
-                rc_percent: powerInfo?.data?.rc_percent || "0%",
-            });
+            const profileInfo = await getProfile(requestUsername);
+            const powerInfo = await getAccountWithPower(requestUsername);
+            if (currentUsernameRef.current !== requestUsername) return;
+            if (profileInfo) {
+                updateProfileData({
+                    name: profileInfo.metadata?.profile?.name || requestUsername,
+                    following: profileInfo.stats?.following || 0,
+                    location: profileInfo.metadata?.profile?.location || "",
+                    about: profileInfo.metadata?.profile?.about || "",
+                });
+                const bridgeCount = profileInfo.stats?.followers ?? 0;
+                const baseline = bridgeFollowersBaselineRef.current;
+                if (
+                    baseline === null ||
+                    baseline.username !== requestUsername ||
+                    bridgeCount !== baseline.count
+                ) {
+                    bridgeFollowersBaselineRef.current = { username: requestUsername, count: bridgeCount };
+                    updateProfileData({ followers: bridgeCount });
+                }
+            }
+            if (powerInfo?.data) {
+                updateProfileData({
+                    vp_percent: powerInfo.data.vp_percent || "0%",
+                    rc_percent: powerInfo.data.rc_percent || "0%",
+                });
+            }
         } catch (err) {
             console.error("Failed to refetch bridge profile info", err);
         }

--- a/lib/hive/client-functions.ts
+++ b/lib/hive/client-functions.ts
@@ -512,8 +512,22 @@ export async function convertVestToHive(amount: number) {
 }
 
 export async function getProfile(username: string) {
-  const profile = await HiveClient.call('bridge', 'get_profile', { account: username });
-  return profile
+  const maxAttempts = 3;
+  const delayMs = 500;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const profile = await HiveClient.call('bridge', 'get_profile', { account: username });
+      // A null/undefined response from a known-valid username is a transient bridge
+      // failure (cold node, indexing lag), not a legitimate "no profile" result.
+      if (profile != null) return profile;
+    } catch {
+      // transient RPC error — retry below
+    }
+    if (attempt < maxAttempts) {
+      await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  return null;
 }
 
 export async function getAccountWithPower(username: string) {


### PR DESCRIPTION
## Summary

Closes #91 (partially — see "Out of scope" below for what's intentionally deferred). Fixes three independent bugs that all surfaced as "profile header/blockchain data not loading on initial page load": a cross-profile race condition, a silent cold-load failure in the Hive bridge call, and a stale follow/following counter. A fourth, unrelated bug (memo comparator blocking re-renders for several profile fields) was found while investigating and is fixed in the same branch since it shares the same code path.

## Root causes (3 independent bugs, 5 commits)

1. **Cross-profile race condition** — `useProfileData.ts`'s cancellation guard (`cancelled` flag) only protected against unmount, not against the same component re-running with a new `username` while an older async response was still in flight. Fast profile-to-profile navigation could write profile A's stale response into profile B's render.
2. **Cold-load silent failure** — `getProfile()` (`lib/hive/client-functions.ts`) made a single, unretried bridge call. A `null` response or thrown error on first load was either treated as a no-op (writing the same zeros already on screen) or silently swallowed, leaving followers stuck at 0 until an unrelated interaction (e.g. clicking Follow) re-triggered the fetch.
3. **Bridge indexing lag on follow/unfollow** — `get_follow_count` is served by Hive's separately-indexed bridge/hivemind service, which lags slightly behind on-chain confirmation. A network refetch immediately after a confirmed follow/unfollow could return pre-action data, making the counter appear to skip an action (it would only catch up on the *next* action).
4. **Stale render for Keychain-authenticated viewers (found during testing, not in the original issue)** — `ProfileHeader.tsx`'s custom `memo` comparator didn't check `followers`, `following`, `name`, `about`, `vp_percent`, or `location` — fields written asynchronously by the bridge fetch. Email/EVM viewers appeared unaffected only by accident (an unrelated prop happened to change around the same time, forcing a re-render); Keychain viewers had no such accidental trigger, so the bridge data update was invisible until something else forced a re-render.

## What changed (5 commits on `fix/profile-follow-counter-race`)

1. **Race condition guard** — `currentUsernameRef`, synchronously updated every effect run, compared against the closure-captured `username` before any `setState` in the async phase.
2. **`refetchBridgeData`** — exposed a manual re-fetch from the hook (later repurposed, see commit 4).
3. **`getProfile()` retry + validation** — 3 attempts, 500ms apart, explicit `null` check with a `console.warn` on exhausted retries instead of a silent zero-write. *(See "Diagnostic logging" below.)*
4. **Optimistic follow-count update** — `adjustFollowerCount(delta)` applied only after a confirmed on-chain follow/unfollow response (never before), sidestepping the bridge indexing lag instead of trying to outrace it with a refetch. `onFollowConfirmed` is rewired from `refetchBridgeData` to this.
5. **Memo comparator fix** — added the 6 missing bridge-phase fields to `ProfileHeader.tsx`'s comparator so Keychain-authenticated views re-render correctly when bridge data resolves.

## Diagnostic logging

`getProfile()` (commit 3) keeps one `console.warn` for when all 3 retry attempts fail — this is intentional production logging for a real failure mode (Hive bridge unreachable), not leftover debug code. Flagging explicitly per team convention of stripping debug logs before commit.

## Testing done (manual)

- [x] Cold load (no prior interaction) on a profile with followers, via email, EVM wallet, and Hive Keychain login — header data (followers, following, name, about, VP%) appears immediately in all three
- [x] Fast navigation between two profiles before the first finishes loading — second profile's data renders, no bleed-through from the first
- [x] Follow on a profile with a known follower count — counter increments immediately, no lag
- [x] Unfollow — counter decrements immediately
- [x] Mobile viewport — same follow/unfollow + cold-load checks
- [x] `pnpm build && pnpm start` (production build) — no console errors during any of the above flows
- [x] Scope check: `git diff main --name-only` — only the 7 files relevant to this fix (`FollowButton.tsx`, `HiveProfileHeader.tsx`, `MobileProfileHeader.tsx`, `ProfileHeader.tsx`, `ProfilePage.tsx`, `useProfileData.ts`, `lib/hive/client-functions.ts`)

## Investigated, found not to be a bug

- **"Skatehive Account" and "Farcaster Profile" tabs missing locally** — traced to the local `.env.local` pointing at a Supabase project without a `userbase` record for the test profile, not a code regression. `Hive Profile` and `Zora Profile` tabs are blockchain-sourced and unaffected by this. No code change needed; flagging here in case it resurfaces in review.

## Out of scope (separate items)

- Folder tab animation (`ViewModeSelector.tsx`) — cosmetic, explicitly deferred from this PR
- `location` field not wired into `HiveProfileHeader`'s desktop `IdentityBlock` (it is wired on mobile) — pre-existing gap, unrelated to the bugs fixed here
- Whether PR #133 fixed the original "folders disappearing" report — retested manually, tabs behave correctly for all viewer auth types; no separate action needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Follow and unfollow actions now update follower counts more reliably and confirm changes after the action completes.
  * Profile pages now refresh profile stats more consistently, with safer updates when switching between profiles.

* **Bug Fixes**
  * Improved handling of slow or temporary profile fetch failures with automatic retry attempts.
  * Reduced the chance of showing stale follow state or follower counts after profile changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->