### PR TITLE
fix: notifications unread badge clears on first click (race condition in markNotificationsAsRead)

### DIFF
--- a/contexts/NotificationContext.tsx
+++ b/contexts/NotificationContext.tsx
@@ -54,7 +54,9 @@ export const NotificationProvider = ({
         getLastReadNotificationDate(effectiveUser),
       ]);
       setNotifications(notifs);
-      setLastReadDate(lastRead);
+      setLastReadDate((prev) =>
+        new Date(lastRead) > new Date(prev) ? lastRead : prev
+      );
     } catch (error) {
       // Error handled silently for production
     } finally {


### PR DESCRIPTION
Closes #157

## Problem
Clicking "Mark as read" required **two clicks** to clear the unread badge. The first click cleared it momentarily, then the badge reappeared. Only the second click made it stick.

## Root cause
Race condition in `NotificationContext`. On first click:

1. `markNotificationsAsRead()` optimistically sets `lastReadDate = now` → badge clears ✅
2. `refreshNotifications()` immediately calls `getLastReadNotificationDate()` from `account_history_api`
3. The broadcast TX from step 1 isn't indexed yet (~3s Hive block time), so the chain returns the **old** `lastReadDate`
4. `setLastReadDate(oldDate)` overwrites the optimistic update → badge reappears ❌

## Fix
One-line change in `contexts/NotificationContext.tsx` — use a functional updater to guard against overwriting a newer local value with a stale chain value:

```ts
// Before
setLastReadDate(lastRead);

// After
setLastReadDate((prev) =>
  new Date(lastRead) > new Date(prev) ? lastRead : prev
);
```

The functional updater receives the actual current state at update time. When the chain returns a stale date, the guard sees it's older than the optimistic value and keeps it. Once the TX is indexed on subsequent refreshes, the chain value catches up and updates normally.

## Tested
Confirmed on `bielcx`: badge clears on first click and stays cleared.