### PR TITLE
fix: /settings chunk error (useFormControlStyles) caused by optimizePackageImports

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -96,7 +96,6 @@ const nextConfig = {
         // into direct subpath imports. These libs all have large index.ts
         // re-exports that defeat tree-shaking otherwise.
         optimizePackageImports: [
-            '@chakra-ui/react',
             '@chakra-ui/icons',
             'react-icons',
             'wagmi',


### PR DESCRIPTION
Closes #159

## Problem
Navigating to `/settings` → "App Account" tab and saving a posting key crashed the page with a chunk error (`useFormControlStyles is not a function`). After the crash, `/settings` remained broken until hard refresh.

## Root cause
`experimental.optimizePackageImports` in `next.config.mjs` included `@chakra-ui/react`. This rewrites Chakra's barrel imports into per-module subpath imports at build time. When a Chakra `FormControl` consumer lands in a separate webpack chunk (via `next/dynamic(..., { ssr: false })` in `PostingKeyDialogContext` and `FarcasterAuthIsland`), that chunk gets its own copy of `@chakra-ui/form-control` instead of sharing the singleton. Two module instances → two different `React.createContext` objects → `useFormControlStyles()` reads a context that was never provided → crash.

Silent in dev — only manifests in production chunk splitting.

## Fix
Remove `"@chakra-ui/react"` from `experimental.optimizePackageImports`. The `ssr: false` dynamic imports are intentional (browser-only deps) and unchanged.

## Files
- `next.config.mjs` — 1 line removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app configuration by removing one package from an import optimization list, while keeping the rest unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->