### PR TITLE
fix: Skatehive logo broken on every page reload (external URL → local asset)

### DIFF
--- a/components/graphics/SidebarLogo.tsx
+++ b/components/graphics/SidebarLogo.tsx
@@ -33,7 +33,7 @@ const SidebarLogo = ({ prioritizeAuctionImage = false }: SidebarLogoProps) => {
     <Image
       src={
         activeAuction?.token?.image ||
-        "https://www.skatehive.app/SKATE_HIVE_VECTOR_FIN.svg"
+        "/SKATE_HIVE_VECTOR_FIN.svg"
       }
       alt="SkateHive Hover Logo"
       style={{ width: "100%", height: "100%", objectFit: "cover" }}

--- a/components/layout/SplashScreen.tsx
+++ b/components/layout/SplashScreen.tsx
@@ -54,7 +54,7 @@ export default function SplashScreen({ onFinish }: { onFinish: () => void }) {
     >
       <Center flexDirection="column">
         <Image
-          src="https://www.skatehive.app/SKATE_HIVE_VECTOR_FIN.svg"
+          src="/SKATE_HIVE_VECTOR_FIN.svg"
           alt="Skatehive Logo"
           width="250px"
         />


### PR DESCRIPTION
Closes #161 

## Problem
On every page reload, the Skatehive logo rendered as a broken image during the loading phase. Affected `SplashScreen` and `SidebarLogo` (hover fallback).

## Root cause
Both components referenced the logo via a hardcoded external URL (`https://www.skatehive.app/SKATE_HIVE_VECTOR_FIN.svg`). On reload, the browser attempts to fetch this external resource before the page is ready — causing the broken image placeholder.

## Fix
Point both components to the local asset `/SKATE_HIVE_VECTOR_FIN.svg`, which already existed in `/public` but wasn't being used.

## Files changed
- `components/layout/SplashScreen.tsx`
- `components/graphics/SidebarLogo.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated logo images to load from a local asset path instead of an external URL, improving reliability in the sidebar and splash screen.
  * This helps ensure the app branding displays consistently even when external resources are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->