### PR TITLE
fix(sponsorship): hide Sponsor CTA for any Hive identity (not just sponsored)

### DIFF
--- a/app/api/userbase/sponsorships/info/[user_id]/route.ts
+++ b/app/api/userbase/sponsorships/info/[user_id]/route.ts
@@ -38,45 +38,50 @@ export async function GET(
   }
 
   try {
-    // Check if user has a sponsored Hive identity
-    const { data: identity, error: identityError } = await supabase
+    // A user is "lite" only if they have NO Hive identity at all. ANY Hive
+    // identity — created via sponsorship, linked manually, or inherited from an
+    // account merge — means they already own a Hive account, so the Sponsor CTA
+    // must be hidden. (The old query filtered is_sponsored=true, so a
+    // manually-linked/merge-inherited identity was misread as lite.)
+    const { data: identities, error: identityError } = await supabase
       .from("userbase_identities")
       .select("handle, is_sponsored, sponsor_user_id, metadata")
       .eq("user_id", userId)
-      .eq("type", "hive")
-      .eq("is_sponsored", true)
-      .single();
+      .eq("type", "hive");
 
-    // PGRST116 = "no rows found" - expected when user has no sponsored identity
-    if (identityError && identityError.code !== "PGRST116") {
+    if (identityError) {
       return NextResponse.json(
         { error: "Database error", details: identityError.message },
         { status: 500 }
       );
     }
 
-    if (!identity) {
-      return NextResponse.json({
-        sponsored: false,
-      });
+    const hiveIdentities = identities ?? [];
+
+    if (hiveIdentities.length === 0) {
+      return NextResponse.json({ has_hive_identity: false, sponsored: false });
     }
 
-    // Get sponsor username
+    // Prefer a sponsored identity (for the "sponsored by X" badge); else any.
+    const sponsoredIdentity = hiveIdentities.find((i) => i.is_sponsored);
+    const identity = sponsoredIdentity ?? hiveIdentities[0];
+
     let sponsorUsername = null;
-    if (identity.sponsor_user_id) {
+    if (sponsoredIdentity?.sponsor_user_id) {
       const { data: sponsorIdentity } = await supabase
         .from("userbase_identities")
         .select("handle")
-        .eq("user_id", identity.sponsor_user_id)
+        .eq("user_id", sponsoredIdentity.sponsor_user_id)
         .eq("type", "hive")
         .single();
 
       sponsorUsername =
-        sponsorIdentity?.handle || identity.metadata?.sponsor_username;
+        sponsorIdentity?.handle || sponsoredIdentity.metadata?.sponsor_username;
     }
 
     return NextResponse.json({
-      sponsored: true,
+      has_hive_identity: true,
+      sponsored: Boolean(sponsoredIdentity),
       hive_username: identity.handle,
       sponsor_username: sponsorUsername,
     });

--- a/hooks/useSponsorshipStatus.ts
+++ b/hooks/useSponsorshipStatus.ts
@@ -45,7 +45,9 @@ export function useSponsorshipStatus(userId: string | null): SponsorshipStatus {
           const data = await sponsorResponse.json();
           setStatus({
             isSponsored: data.sponsored || false,
-            isLite: !data.sponsored,
+            // Lite ONLY when the user has no Hive identity at all — a linked or
+            // merge-inherited Hive account (sponsored or not) hides the CTA.
+            isLite: !data.has_hive_identity,
             sponsorUsername: data.sponsor_username,
             hiveUsername: data.hive_username,
             loading: false,


### PR DESCRIPTION
## Bug
A post by `@skateuser` (a soft-post reattached to a surviving user after an account **merge**, e.g. `well13`) kept showing the **Sponsor** button — even though that user already has a Hive account.

## Root cause
`sponsorships/info/[user_id]` queried `userbase_identities` with `.eq("is_sponsored", true)`, so it only recognized identities **created via sponsorship**. A Hive identity that was **linked manually** or **inherited from a merge** (`is_sponsored != true`) returned `sponsored:false`, and `useSponsorshipStatus` did `isLite = !sponsored` → the user was misclassified as lite → Sponsor CTA shown.

## Fix
Sponsor exists to give a *lite* user a Hive account. Correct rule: **lite = no Hive identity at all**.
- Route: drop the `is_sponsored=true` filter; fetch all `type="hive"` identities and return `has_hive_identity`. Still surfaces `sponsored` + `sponsor_username` (prefers a sponsored identity for the badge) — backward compatible.
- Hook: `isLite = !data.has_hive_identity`.

## Notes
- `sponsorships/*` is **web-only** (never migrated to `skatehive-api`), so this is the correct owner.
- Verified: `tsc --noEmit` clean. Supersedes/duplicates the pending patch discussed in chat (same two files) — this version is tsc-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sponsorship status handling for accounts with Hive identities, reducing cases where users were incorrectly marked as lite or sponsored.
  * Sponsor and Hive username details now display more accurately when multiple linked identities exist.
  * Users without any Hive identity continue to be shown as lite, while users with Hive identities are classified more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->