### PR TITLE
feat(magazine): render the curated issue from the ops portal

### DIFF
--- a/app/magazine/page.tsx
+++ b/app/magazine/page.tsx
@@ -1,14 +1,68 @@
 "use client";
+import { useEffect, useState } from "react";
+import { Discussion } from "@hiveio/dhive";
 import Magazine from "@/components/shared/Magazine";
 import TopBar from "@/components/blog/TopBar";
 import { Box } from "@chakra-ui/react";
 import { HIVE_CONFIG } from "@/config/app.config";
 
+// The ops portal curates the magazine (which posts + order) and serves the
+// published issue here. Falls back to the community feed if none is published.
+const MAGAZINE_API =
+  process.env.NEXT_PUBLIC_MAGAZINE_API || "https://skatehive.reelflip.com";
+
 export default function MagazinePage() {
-  // Show posts from the community, 30 at a time
+  // Fallback: latest community posts (the original behavior).
   const communityTag = HIVE_CONFIG.COMMUNITY_TAG;
   const tag = [{ tag: communityTag, limit: 20 }]; // Bridge API max limit is 20
-  const query = "created"; // or 'trending', 'hot', etc.
+  const query = "created";
+
+  const [curated, setCurated] = useState<Discussion[] | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let live = true;
+    fetch(`${MAGAZINE_API}/api/magazine/current?project=skatehive`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!live) return;
+        const posts = Array.isArray(data?.posts) ? data.posts : [];
+        if (posts.length > 0) {
+          // Map the portal feed → the Discussion shape the flipbook renders.
+          setCurated(
+            posts.map(
+              (p: {
+                author: string;
+                permlink: string;
+                title: string;
+                body: string;
+                created: string;
+                payout?: number;
+                thumbnail?: string | null;
+              }) =>
+                ({
+                  author: p.author,
+                  permlink: p.permlink,
+                  title: p.title,
+                  body: p.body,
+                  created: p.created,
+                  pending_payout_value: `${(p.payout ?? 0).toFixed(3)} HBD`,
+                  json_metadata: JSON.stringify({
+                    image: p.thumbnail ? [p.thumbnail] : [],
+                  }),
+                }) as unknown as Discussion,
+            ),
+          );
+        }
+        setLoaded(true);
+      })
+      .catch(() => {
+        if (live) setLoaded(true);
+      });
+    return () => {
+      live = false;
+    };
+  }, []);
 
   return (
     <Box
@@ -24,7 +78,11 @@ export default function MagazinePage() {
       }}
     >
       <TopBar viewMode="magazine" setViewMode={() => {}} setQuery={() => {}} />
-      <Magazine tag={tag} query={query} />
+      {loaded && curated && curated.length > 0 ? (
+        <Magazine posts={curated} preserveOrder />
+      ) : (
+        <Magazine tag={tag} query={query} />
+      )}
     </Box>
   );
 }

--- a/components/shared/Magazine.tsx
+++ b/components/shared/Magazine.tsx
@@ -147,6 +147,10 @@ export interface MagazineProps {
   userProfileImage?: string;
   displayName?: string;
   userLocation?: string;
+  // When the posts are an editorial pick (e.g. the curated magazine issue from
+  // the ops portal), keep the given selection + order as-is: skip the quality
+  // filter and the payout re-sort.
+  preserveOrder?: boolean;
 }
 
 export default function Magazine(props: MagazineProps) {
@@ -224,6 +228,9 @@ export default function Magazine(props: MagazineProps) {
   const filteredPosts = useMemo(() => {
     if (!posts || !isInitialized) return [];
 
+    // Editorial issue: trust the curator's selection + order verbatim.
+    if (props.preserveOrder) return posts;
+
     // First apply quality filters (reputation and downvote filtering)
     const qualityFilteredPosts = filterAutoComments(posts);
 
@@ -234,7 +241,7 @@ export default function Magazine(props: MagazineProps) {
     );
 
     return sortedPosts;
-  }, [posts, isInitialized]);
+  }, [posts, isInitialized, props.preserveOrder]);
 
   const playSound = () => {
     if (audioRef.current) {


### PR DESCRIPTION
## What
The magazine flipbook currently shows the **latest ≤20 community posts** (Hive Bridge), then **re-sorts them by payout** — there's no editorial control over what's in the magazine or its order.

This wires the flipbook to the **curated issue** the ops portal publishes, with a safe fallback.

## How
- **`Magazine.tsx`** — new optional `preserveOrder` prop. When set (an editorial pick), it skips the quality filter + payout re-sort, so the curator's exact selection and order render as-is.
- **`app/magazine/page.tsx`** — fetches `GET {NEXT_PUBLIC_MAGAZINE_API}/api/magazine/current?project=skatehive` (default `https://skatehive.reelflip.com`), maps the feed to the `Discussion` shape the flipbook expects, and renders `<Magazine posts={curated} preserveOrder />`. **If no issue is published (empty feed), it falls back to the original community feed** — so nothing breaks before curation exists.

## Backend (already shipped in the ops portal)
- `MagazineIssue` / `MagazineIssuePost` (ordered post refs) curated in the portal at `/magazine`.
- Public, CORS-open, cached `GET /api/magazine/current?project=<slug>` returns the latest **published** issue, hydrated (title/body/created/payout/thumbnail) via Hive `bridge.get_post`, in issue order.

## Config
- Optional env `NEXT_PUBLIC_MAGAZINE_API` to point at a different portal deployment. Defaults to the SkateHive portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Magazine page can now show a curated “current issue” when available, giving users a more handpicked reading experience.
  * Curated posts keep their original order for a more magazine-like layout.

* **Bug Fixes**
  * If curated content fails to load or isn’t available, the page now automatically falls back to the standard community feed.
  * Post details such as author, title, date, payout, and images are now mapped consistently in the Magazine view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->