### PR TITLE
fix: false unread notification badge (Hive timestamps parsed as local time)

### DIFF
--- a/components/notifications/utils/mediaExtraction.ts
+++ b/components/notifications/utils/mediaExtraction.ts
@@ -1,4 +1,5 @@
 import { getImageUrls } from "@/lib/hive/metadata-utils";
+import { parseHiveDate } from "@/lib/utils/hiveDate";
 
 export interface ExtractedMedia {
   previewUrl: string | null;
@@ -242,7 +243,7 @@ export function sanitizeNotificationBody(
  * Format notification date for display
  */
 export function formatNotificationDate(dateString: string): string {
-  return new Date(dateString + "Z").toLocaleString("en-US", {
+  return parseHiveDate(dateString).toLocaleString("en-US", {
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
@@ -260,12 +261,7 @@ export function isNotificationNew(
   notificationDate: string,
   lastReadDate: string
 ): boolean {
-  const notificationDateStr = notificationDate.endsWith("Z")
-    ? notificationDate
-    : `${notificationDate}Z`;
-  const notifDate = new Date(notificationDateStr);
-  const lastRead = new Date(lastReadDate);
-  return notifDate > lastRead;
+  return parseHiveDate(notificationDate) > parseHiveDate(lastReadDate);
 }
 
 /**

--- a/contexts/NotificationContext.tsx
+++ b/contexts/NotificationContext.tsx
@@ -12,6 +12,7 @@ import {
   fetchNewNotifications,
   getLastReadNotificationDate,
 } from "@/lib/hive/client-functions";
+import { parseHiveDate } from "@/lib/utils/hiveDate";
 
 interface NotificationContextProps {
   notifications: Notifications[];
@@ -55,7 +56,7 @@ export const NotificationProvider = ({
       ]);
       setNotifications(notifs);
       setLastReadDate((prev) =>
-        new Date(lastRead) > new Date(prev) ? lastRead : prev
+        parseHiveDate(lastRead) > parseHiveDate(prev) ? lastRead : prev
       );
     } catch (error) {
       // Error handled silently for production
@@ -83,38 +84,17 @@ export const NotificationProvider = ({
     setFarcasterEnabled(false);
   }, []);
 
-  // Helper function to safely parse dates
-  const parseNotificationDate = useCallback((dateString: string): Date => {
-    // Handle various date formats more robustly
-    try {
-      // If the date already has timezone info, use it as-is
-      if (
-        dateString.includes("Z") ||
-        dateString.includes("+") ||
-        dateString.includes("-")
-      ) {
-        return new Date(dateString);
-      }
-      // If no timezone info, assume it's UTC (common for blockchain timestamps)
-      return new Date(dateString + "Z");
-    } catch (error) {
-      return new Date(0); // Return epoch as fallback
-    }
-  }, []);
-
   // Memoize the notification count calculation to avoid recalculating on every render
   const newNotificationCount = useMemo(() => {
     if (!notifications || notifications.length === 0) return 0;
 
-    const lastReadTimestamp = new Date(lastReadDate).getTime();
+    const lastReadTimestamp = parseHiveDate(lastReadDate).getTime();
 
-    return notifications.filter((notification) => {
-      const notificationTimestamp = parseNotificationDate(
-        notification.date
-      ).getTime();
-      return notificationTimestamp > lastReadTimestamp;
-    }).length;
-  }, [notifications, lastReadDate, parseNotificationDate]);
+    return notifications.filter(
+      (notification) =>
+        parseHiveDate(notification.date).getTime() > lastReadTimestamp
+    ).length;
+  }, [notifications, lastReadDate]);
 
   // Load notifications when user changes
   useEffect(() => {

--- a/lib/utils/__tests__/hiveDate.test.ts
+++ b/lib/utils/__tests__/hiveDate.test.ts
@@ -1,0 +1,34 @@
+import assert from "assert";
+import { parseHiveDate } from "../hiveDate";
+
+// Zone-less Hive timestamp must be read as UTC regardless of the machine's
+// timezone. The old parser treated it as local time because its timezone
+// check matched the hyphens in the DATE part, which caused the notification
+// badge to stay lit after mark-as-read for users west of UTC.
+assert.strictEqual(
+  parseHiveDate("2026-07-09T14:30:00").getTime(),
+  Date.UTC(2026, 6, 9, 14, 30, 0),
+  "zone-less timestamp should parse as UTC"
+);
+
+// Explicit designators must pass through untouched.
+assert.strictEqual(
+  parseHiveDate("2026-07-09T14:30:00.000Z").getTime(),
+  Date.UTC(2026, 6, 9, 14, 30, 0),
+  "Z-suffixed timestamp should not be double-suffixed"
+);
+assert.strictEqual(
+  parseHiveDate("2026-07-09T11:30:00-03:00").getTime(),
+  Date.UTC(2026, 6, 9, 14, 30, 0),
+  "offset timestamp should be respected"
+);
+
+// The badge scenario: notification arrived before mark-as-read → not new.
+const notificationDate = "2026-07-09T14:00:00"; // bridge format, UTC
+const lastRead = "2026-07-09T15:00:00.000Z"; // stored by mark-as-read
+assert.ok(
+  parseHiveDate(notificationDate) < parseHiveDate(lastRead),
+  "notification older than lastRead must not count as unread"
+);
+
+console.log("✅ hiveDate tests passed");

--- a/lib/utils/hiveDate.ts
+++ b/lib/utils/hiveDate.ts
@@ -1,0 +1,13 @@
+/**
+ * Hive API timestamps (bridge notifications, account history, custom_json
+ * payloads) are UTC but usually lack a timezone designator
+ * ("2026-07-09T14:30:00"). Bare `new Date()` parses those as LOCAL time,
+ * shifting every comparison by the user's UTC offset.
+ */
+export function parseHiveDate(dateString: string): Date {
+  // Keep strings that already carry an explicit timezone (Z or ±HH:MM);
+  // otherwise mark the value as UTC before parsing.
+  return /Z$|[+-]\d{2}:\d{2}$/i.test(dateString)
+    ? new Date(dateString)
+    : new Date(dateString + "Z");
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "next lint",
     "lint:fix": "next lint --fix",
     "type-check": "tsc --noEmit",
-    "test": "tsx lib/utils/__tests__/LRUCache.test.ts && tsx lib/utils/__tests__/hashUtils.test.ts && tsx lib/markdown/__tests__/MarkdownRenderer.test.ts",
+    "test": "tsx lib/utils/__tests__/LRUCache.test.ts && tsx lib/utils/__tests__/hashUtils.test.ts && tsx lib/markdown/__tests__/MarkdownRenderer.test.ts && tsx lib/utils/__tests__/hiveDate.test.ts",
     "test:lru": "tsx lib/utils/__tests__/LRUCache.test.ts",
     "test:hash": "tsx lib/utils/__tests__/hashUtils.test.ts",
     "approve-builds": "pnpm config set strict-peer-dependencies false && pnpm install",


### PR DESCRIPTION
Fixes #170

## Problem

The red unread dot on **Notifications** stays lit after marking everything as read, then clears itself hours later on its own.

## Root cause

`parseNotificationDate` in `NotificationContext` tried to detect timezone info with `dateString.includes("-")` — but every ISO date contains hyphens in the DATE part (`2026-07-09...`), so the "assume UTC" branch was unreachable. Hive bridge timestamps are UTC **without** a `Z` (`2026-07-09T14:30:00`), so they were parsed as **local time**.

For any user west of UTC (e.g. Brazil, UTC-3), every notification is timestamped N hours into the future. Mark-as-read stores the real "now", so everything received in the last N hours keeps counting as unread — a false alert that self-heals after exactly the UTC offset. The per-item list uses a different (correct) parser in `mediaExtraction.ts`, which is why items showed as read while the badge stayed lit.

Repro (UTC-3): notification from 1h ago → parsed 2h "into the future" → `count > 0` for 3 more hours after mark-as-read.

## Fix

- New `lib/utils/hiveDate.ts` → `parseHiveDate()`: appends `Z` only when the string has no timezone designator (`Z` or `±HH:MM` suffix).
- `NotificationContext`: badge count and `lastReadDate` comparisons now use it (replaces the broken parser). `lastReadDate` is normalized too, since other frontends store zone-less dates in the on-chain `notify` custom_json.
- `mediaExtraction.ts`: `isNotificationNew` and `formatNotificationDate` unified on the same parser (also fixes a latent double-`Z` bug in formatting).
- Test added following the repo's `tsx` assert convention, wired into `npm test`.
