### PR TITLE
fix(magazine): curated edition in the blog magazine modal (/blog?view=magazine)

### DIFF
--- a/app/magazine/page.tsx
+++ b/app/magazine/page.tsx
@@ -1,68 +1,18 @@
 "use client";
-import { useEffect, useState } from "react";
-import { Discussion } from "@hiveio/dhive";
 import Magazine from "@/components/shared/Magazine";
 import TopBar from "@/components/blog/TopBar";
 import { Box } from "@chakra-ui/react";
 import { HIVE_CONFIG } from "@/config/app.config";
+import { useCuratedMagazine } from "@/hooks/useCuratedMagazine";
 
-// The ops portal curates the magazine (which posts + order) and serves the
-// published issue here. Falls back to the community feed if none is published.
-const MAGAZINE_API =
-  process.env.NEXT_PUBLIC_MAGAZINE_API || "https://skatehive.reelflip.com";
-
+// The ops portal curates the magazine (which posts + order); this page shows the
+// published edition and falls back to the community feed when none is published.
 export default function MagazinePage() {
-  // Fallback: latest community posts (the original behavior).
   const communityTag = HIVE_CONFIG.COMMUNITY_TAG;
   const tag = [{ tag: communityTag, limit: 20 }]; // Bridge API max limit is 20
   const query = "created";
 
-  const [curated, setCurated] = useState<Discussion[] | null>(null);
-  const [loaded, setLoaded] = useState(false);
-
-  useEffect(() => {
-    let live = true;
-    fetch(`${MAGAZINE_API}/api/magazine/current?project=skatehive`)
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data) => {
-        if (!live) return;
-        const posts = Array.isArray(data?.posts) ? data.posts : [];
-        if (posts.length > 0) {
-          // Map the portal feed → the Discussion shape the flipbook renders.
-          setCurated(
-            posts.map(
-              (p: {
-                author: string;
-                permlink: string;
-                title: string;
-                body: string;
-                created: string;
-                payout?: number;
-                thumbnail?: string | null;
-              }) =>
-                ({
-                  author: p.author,
-                  permlink: p.permlink,
-                  title: p.title,
-                  body: p.body,
-                  created: p.created,
-                  pending_payout_value: `${(p.payout ?? 0).toFixed(3)} HBD`,
-                  json_metadata: JSON.stringify({
-                    image: p.thumbnail ? [p.thumbnail] : [],
-                  }),
-                }) as unknown as Discussion,
-            ),
-          );
-        }
-        setLoaded(true);
-      })
-      .catch(() => {
-        if (live) setLoaded(true);
-      });
-    return () => {
-      live = false;
-    };
-  }, []);
+  const { curated, loaded } = useCuratedMagazine(true);
 
   return (
     <Box

--- a/components/shared/MagazineModal.tsx
+++ b/components/shared/MagazineModal.tsx
@@ -10,6 +10,7 @@ import {
 } from "@chakra-ui/react";
 import Magazine from "./Magazine";
 import { Discussion } from "@hiveio/dhive";
+import { useCuratedMagazine } from "@/hooks/useCuratedMagazine";
 
 interface MagazineModalProps {
   isOpen: boolean;
@@ -76,8 +77,13 @@ const MagazineModal = React.memo(function MagazineModal({
       : magazineTag || []; // Bridge API max limit is 20
   }, [hiveUsername, magazineTag]);
 
-  // If posts are provided (profile view), use them directly
-  // Otherwise, let Magazine component fetch posts using tag/query (blog view)
+  // Community/blog magazine (no explicit posts, no profile user): show the
+  // curated edition the ops portal published, falling back to the live feed.
+  const isCommunity = posts === undefined && !hiveUsername;
+  const { curated, loaded } = useCuratedMagazine(isCommunity);
+
+  // If posts are provided (profile view), use them directly.
+  // Community view → curated edition (or fallback). Otherwise tag/query.
   const magazineProps = useMemo(() => {
     if (posts !== undefined) {
       // Don't pass tag/query when providing posts directly
@@ -91,6 +97,11 @@ const MagazineModal = React.memo(function MagazineModal({
         displayName,
         userLocation,
       };
+    }
+    if (isCommunity) {
+      if (!loaded) return { posts: [], isLoading: true };
+      if (curated && curated.length > 0) return { posts: curated, preserveOrder: true };
+      // no published edition → fall back to the live community feed below
     }
     return {
       tag,
@@ -106,6 +117,9 @@ const MagazineModal = React.memo(function MagazineModal({
     userProfileImage,
     displayName,
     userLocation,
+    isCommunity,
+    curated,
+    loaded,
   ]);
 
   if (!isOpen) return null;

--- a/hooks/useCuratedMagazine.ts
+++ b/hooks/useCuratedMagazine.ts
@@ -1,0 +1,63 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Discussion } from "@hiveio/dhive";
+
+// Fetches the curated magazine issue published by the ops portal and maps it to
+// the Discussion shape the flipbook renders. Shared by the /magazine page and
+// the blog's MagazineModal so both show the same curated edition (with a
+// fallback to the community feed when nothing is published). `enabled` lets the
+// profile magazine skip the fetch.
+const MAGAZINE_API =
+  process.env.NEXT_PUBLIC_MAGAZINE_API || "https://skatehive.reelflip.com";
+
+export function useCuratedMagazine(enabled: boolean = true): { curated: Discussion[] | null; loaded: boolean } {
+  const [curated, setCurated] = useState<Discussion[] | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      setLoaded(true);
+      return;
+    }
+    let live = true;
+    fetch(`${MAGAZINE_API}/api/magazine/current?project=skatehive`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!live) return;
+        const posts = Array.isArray(data?.posts) ? data.posts : [];
+        if (posts.length > 0) {
+          setCurated(
+            posts.map(
+              (p: {
+                author: string;
+                permlink: string;
+                title: string;
+                body: string;
+                created: string;
+                payout?: number;
+                thumbnail?: string | null;
+              }) =>
+                ({
+                  author: p.author,
+                  permlink: p.permlink,
+                  title: p.title,
+                  body: p.body,
+                  created: p.created,
+                  pending_payout_value: `${(p.payout ?? 0).toFixed(3)} HBD`,
+                  json_metadata: JSON.stringify({ image: p.thumbnail ? [p.thumbnail] : [] }),
+                }) as unknown as Discussion,
+            ),
+          );
+        }
+        setLoaded(true);
+      })
+      .catch(() => {
+        if (live) setLoaded(true);
+      });
+    return () => {
+      live = false;
+    };
+  }, [enabled]);
+
+  return { curated, loaded };
+}


### PR DESCRIPTION
## Problem
#169 wired only the standalone **`/magazine`** page to the curated feed. But the magazine users actually open is the **modal at `/blog?view=magazine`** (`app/blog/page.tsx` → `<MagazineModal magazineTag magazineQuery>`), which still rendered the **raw Bridge community feed** — so a curated edition published in the ops portal never appeared there.

## Fix
- New shared hook **`hooks/useCuratedMagazine.ts`** — fetches `{NEXT_PUBLIC_MAGAZINE_API}/api/magazine/current?project=skatehive` and maps it to the `Discussion` shape (title/body/created/payout/thumbnail).
- **`MagazineModal`** — for the community view (no explicit `posts`, no `hiveUsername`) it now uses the hook: shows the **curated edition** with `preserveOrder`, and **falls back to the live community feed** when nothing is published. Profile magazines are unaffected.
- **`/magazine` page** — refactored to use the same hook (removes the duplicated inline fetch).

Both entry points now render the same curated edition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a curated magazine edition, with automatic fallback to the community feed when no published edition is available.
  * Magazine views and modal previews now load curated content consistently across the app.

* **Bug Fixes**
  * Improved loading and fallback behavior so the magazine page and modal handle unavailable or incomplete content more gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->