### PR TITLE
feat(magazine): /magazine cover selector + fullscreen edition preview

### DIFF
--- a/app/magazine/page.tsx
+++ b/app/magazine/page.tsx
@@ -1,18 +1,39 @@
 "use client";
-import Magazine from "@/components/shared/Magazine";
+import { useState } from "react";
+import { Discussion } from "@hiveio/dhive";
+import {
+  Box,
+  SimpleGrid,
+  Image,
+  Text,
+  Badge,
+  Spinner,
+  Button,
+  VStack,
+  AspectRatio,
+} from "@chakra-ui/react";
 import TopBar from "@/components/blog/TopBar";
-import { Box } from "@chakra-ui/react";
+import MagazineModal from "@/components/shared/MagazineModal";
 import { HIVE_CONFIG } from "@/config/app.config";
-import { useCuratedMagazine } from "@/hooks/useCuratedMagazine";
+import { useMagazineIssues, fetchMagazineIssuePosts } from "@/hooks/useCuratedMagazine";
 
-// The ops portal curates the magazine (which posts + order); this page shows the
-// published edition and falls back to the community feed when none is published.
+// The magazine route is a COVER SELECTOR: the accumulating archive of published
+// editions (from the ops portal) shown as covers → click one to flip through it
+// fullscreen. Falls back to the community magazine when nothing is published.
+const DEFAULT_COVER = "/images/covers/nogenta_cover.png";
+
 export default function MagazinePage() {
-  const communityTag = HIVE_CONFIG.COMMUNITY_TAG;
-  const tag = [{ tag: communityTag, limit: 20 }]; // Bridge API max limit is 20
-  const query = "created";
+  const { issues, loaded } = useMagazineIssues();
+  const [openPosts, setOpenPosts] = useState<Discussion[] | null>(null);
+  const [loadingIssue, setLoadingIssue] = useState<number | null>(null);
+  const [communityOpen, setCommunityOpen] = useState(false);
 
-  const { curated, loaded } = useCuratedMagazine(true);
+  async function openIssue(number: number) {
+    setLoadingIssue(number);
+    const posts = await fetchMagazineIssuePosts(number);
+    setLoadingIssue(null);
+    if (posts.length > 0) setOpenPosts(posts);
+  }
 
   return (
     <Box
@@ -22,16 +43,83 @@ export default function MagazinePage() {
       maxH="100vh"
       overflowY="auto"
       p={0}
-      sx={{
-        "&::-webkit-scrollbar": { display: "none" },
-        scrollbarWidth: "none",
-      }}
+      sx={{ "&::-webkit-scrollbar": { display: "none" }, scrollbarWidth: "none" }}
     >
       <TopBar viewMode="magazine" setViewMode={() => {}} setQuery={() => {}} />
-      {loaded && curated && curated.length > 0 ? (
-        <Magazine posts={curated} preserveOrder />
-      ) : (
-        <Magazine tag={tag} query={query} />
+
+      <Box p={{ base: 4, md: 6 }}>
+        <Text fontSize="2xl" fontWeight="bold" color="text" mb={1}>
+          SkateHive Magazine
+        </Text>
+        <Text color="dim" mb={5}>
+          Escolha uma edição para folhear.
+        </Text>
+
+        {!loaded ? (
+          <VStack py={20}>
+            <Spinner color="primary" />
+          </VStack>
+        ) : issues.length === 0 ? (
+          <VStack py={16} spacing={3}>
+            <Text color="dim">Nenhuma edição publicada ainda.</Text>
+            <Button onClick={() => setCommunityOpen(true)} variant="outline">
+              Ver revista da comunidade
+            </Button>
+          </VStack>
+        ) : (
+          <SimpleGrid columns={{ base: 2, md: 3, lg: 4 }} spacing={4}>
+            {issues.map((iss) => (
+              <Box
+                key={iss.number}
+                as="button"
+                onClick={() => openIssue(iss.number)}
+                textAlign="left"
+                borderWidth="1px"
+                borderColor="border"
+                borderRadius="lg"
+                overflow="hidden"
+                bg="muted"
+                position="relative"
+                transition="all .15s"
+                _hover={{ borderColor: "primary", transform: "translateY(-2px)" }}
+              >
+                <AspectRatio ratio={3 / 4}>
+                  <Image src={iss.coverUrl || DEFAULT_COVER} alt={iss.title} objectFit="cover" fallbackSrc={DEFAULT_COVER} />
+                </AspectRatio>
+                {iss.active && (
+                  <Badge position="absolute" top={2} left={2} colorScheme="green">
+                    No ar
+                  </Badge>
+                )}
+                {loadingIssue === iss.number && (
+                  <Box position="absolute" inset={0} bg="blackAlpha.700" display="flex" alignItems="center" justifyContent="center">
+                    <Spinner color="white" />
+                  </Box>
+                )}
+                <Box p={2}>
+                  <Text fontSize="xs" color="dim">
+                    #{iss.number} · {iss.postCount} posts
+                  </Text>
+                  <Text fontSize="sm" fontWeight="semibold" color="text" noOfLines={1}>
+                    {iss.title}
+                  </Text>
+                </Box>
+              </Box>
+            ))}
+          </SimpleGrid>
+        )}
+      </Box>
+
+      {/* Fullscreen flipbook of the chosen edition */}
+      {openPosts && <MagazineModal isOpen onClose={() => setOpenPosts(null)} posts={openPosts} preserveOrder />}
+      {/* Fallback: community magazine when no edition is published */}
+      {communityOpen && (
+        <MagazineModal
+          isOpen
+          onClose={() => setCommunityOpen(false)}
+          magazineTag={[{ tag: HIVE_CONFIG.COMMUNITY_TAG, limit: 20 }]}
+          magazineQuery="created"
+        />
       )}
     </Box>
   );

--- a/components/shared/MagazineModal.tsx
+++ b/components/shared/MagazineModal.tsx
@@ -19,6 +19,8 @@ interface MagazineModalProps {
   hiveUsername?: string;
   posts?: Discussion[];
   isLoading?: boolean;
+  // Keep the given posts' selection + order verbatim (editorial edition).
+  preserveOrder?: boolean;
   // For tag-based magazine (blog view)
   magazineTag?: { tag: string; limit: number }[];
   magazineQuery?: string;
@@ -45,6 +47,7 @@ const MagazineModal = React.memo(function MagazineModal({
   hiveUsername,
   posts,
   isLoading,
+  preserveOrder,
   magazineTag,
   magazineQuery = "created",
   zineCover,
@@ -90,6 +93,7 @@ const MagazineModal = React.memo(function MagazineModal({
       return {
         posts,
         isLoading,
+        preserveOrder,
         error: null,
         zineCover,
         hiveUsername,
@@ -110,6 +114,7 @@ const MagazineModal = React.memo(function MagazineModal({
   }, [
     posts,
     isLoading,
+    preserveOrder,
     tag,
     currentQuery,
     zineCover,

--- a/hooks/useCuratedMagazine.ts
+++ b/hooks/useCuratedMagazine.ts
@@ -2,13 +2,50 @@
 import { useEffect, useState } from "react";
 import { Discussion } from "@hiveio/dhive";
 
-// Fetches the curated magazine issue published by the ops portal and maps it to
-// the Discussion shape the flipbook renders. Shared by the /magazine page and
-// the blog's MagazineModal so both show the same curated edition (with a
-// fallback to the community feed when nothing is published). `enabled` lets the
-// profile magazine skip the fetch.
+// Client hooks for the curated magazine served by the ops portal.
+//   useCuratedMagazine() — the current (latest published) edition, mapped to the
+//     flipbook's Discussion shape. Used by the blog MagazineModal + as the
+//     default preview. Falls back to the community feed when nothing published.
+//   useMagazineIssues() — the accumulating archive (covers) for the selector.
+//   fetchMagazineIssuePosts(number) — one edition's posts (for opening a cover).
 const MAGAZINE_API =
   process.env.NEXT_PUBLIC_MAGAZINE_API || "https://skatehive.reelflip.com";
+
+type PortalPost = {
+  author: string;
+  permlink: string;
+  title: string;
+  body: string;
+  created: string;
+  payout?: number;
+  thumbnail?: string | null;
+};
+
+export type MagazineIssueSummary = {
+  number: number;
+  title: string;
+  coverUrl: string | null;
+  publishedAt: string | null;
+  postCount: number;
+  active: boolean;
+};
+
+/** Map the portal feed → the Discussion shape the flipbook renders. */
+function mapPortalPosts(raw: unknown): Discussion[] {
+  const posts = Array.isArray(raw) ? (raw as PortalPost[]) : [];
+  return posts.map(
+    (p) =>
+      ({
+        author: p.author,
+        permlink: p.permlink,
+        title: p.title,
+        body: p.body,
+        created: p.created,
+        pending_payout_value: `${(p.payout ?? 0).toFixed(3)} HBD`,
+        json_metadata: JSON.stringify({ image: p.thumbnail ? [p.thumbnail] : [] }),
+      }) as unknown as Discussion,
+  );
+}
 
 export function useCuratedMagazine(enabled: boolean = true): { curated: Discussion[] | null; loaded: boolean } {
   const [curated, setCurated] = useState<Discussion[] | null>(null);
@@ -24,31 +61,8 @@ export function useCuratedMagazine(enabled: boolean = true): { curated: Discussi
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
         if (!live) return;
-        const posts = Array.isArray(data?.posts) ? data.posts : [];
-        if (posts.length > 0) {
-          setCurated(
-            posts.map(
-              (p: {
-                author: string;
-                permlink: string;
-                title: string;
-                body: string;
-                created: string;
-                payout?: number;
-                thumbnail?: string | null;
-              }) =>
-                ({
-                  author: p.author,
-                  permlink: p.permlink,
-                  title: p.title,
-                  body: p.body,
-                  created: p.created,
-                  pending_payout_value: `${(p.payout ?? 0).toFixed(3)} HBD`,
-                  json_metadata: JSON.stringify({ image: p.thumbnail ? [p.thumbnail] : [] }),
-                }) as unknown as Discussion,
-            ),
-          );
-        }
+        const mapped = mapPortalPosts(data?.posts);
+        if (mapped.length > 0) setCurated(mapped);
         setLoaded(true);
       })
       .catch(() => {
@@ -60,4 +74,41 @@ export function useCuratedMagazine(enabled: boolean = true): { curated: Discussi
   }, [enabled]);
 
   return { curated, loaded };
+}
+
+/** The accumulating published-edition archive (newest first) for the cover selector. */
+export function useMagazineIssues(): { issues: MagazineIssueSummary[]; loaded: boolean } {
+  const [issues, setIssues] = useState<MagazineIssueSummary[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let live = true;
+    fetch(`${MAGAZINE_API}/api/magazine/issues?project=skatehive`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!live) return;
+        if (Array.isArray(data?.issues)) setIssues(data.issues as MagazineIssueSummary[]);
+        setLoaded(true);
+      })
+      .catch(() => {
+        if (live) setLoaded(true);
+      });
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  return { issues, loaded };
+}
+
+/** Posts of a specific published edition (for opening a chosen cover). */
+export async function fetchMagazineIssuePosts(number: number): Promise<Discussion[]> {
+  try {
+    const r = await fetch(`${MAGAZINE_API}/api/magazine/issue?project=skatehive&number=${number}`);
+    if (!r.ok) return [];
+    const data = await r.json();
+    return mapPortalPosts(data?.posts);
+  } catch {
+    return [];
+  }
 }


### PR DESCRIPTION
## What
Turns the **`/magazine`** route into a **cover selector** over the accumulating archive of published editions curated in the ops portal:
- A responsive **grid of edition covers** (cover image, title, `#number`, post count, an "No ar" badge on the active one).
- Click a cover → **flip through that edition fullscreen** (reuses `MagazineModal`).
- **Falls back** to the community magazine when no edition is published.

The blog magazine modal (`/blog?view=magazine`) stays as-is — it shows the current/active edition (from #172). This just makes `/magazine` the browsable archive with cover selection.

## Changes
- **`hooks/useCuratedMagazine.ts`**: add `useMagazineIssues()` (archive list) + `fetchMagazineIssuePosts(number)` + shared `mapPortalPosts()`.
- **`MagazineModal`**: `preserveOrder` passthrough so a chosen edition keeps its curated order (skips the payout re-sort) when opened from a cover.
- **`app/magazine/page.tsx`**: the cover-selector UI.

## Backend (already deployed in the ops portal)
- `GET /api/magazine/issues?project=skatehive` — the published archive (covers).
- `GET /api/magazine/issue?project=skatehive&number=N` — one edition, hydrated.
- `GET /api/magazine/current` — latest published (used by the blog modal).

Cover URL is any public image link set per edition in the portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)