### PR TITLE
fix(magazine): use the edition's cover on the flipbook cover page

### DIFF
--- a/app/magazine/page.tsx
+++ b/app/magazine/page.tsx
@@ -15,7 +15,7 @@ import {
 import TopBar from "@/components/blog/TopBar";
 import MagazineModal from "@/components/shared/MagazineModal";
 import { HIVE_CONFIG } from "@/config/app.config";
-import { useMagazineIssues, fetchMagazineIssuePosts } from "@/hooks/useCuratedMagazine";
+import { useMagazineIssues, fetchMagazineIssue } from "@/hooks/useCuratedMagazine";
 
 // The magazine route is a COVER SELECTOR: the accumulating archive of published
 // editions (from the ops portal) shown as covers → click one to flip through it
@@ -25,14 +25,18 @@ const DEFAULT_COVER = "/images/covers/nogenta_cover.png";
 export default function MagazinePage() {
   const { issues, loaded } = useMagazineIssues();
   const [openPosts, setOpenPosts] = useState<Discussion[] | null>(null);
+  const [openCover, setOpenCover] = useState<string | null>(null);
   const [loadingIssue, setLoadingIssue] = useState<number | null>(null);
   const [communityOpen, setCommunityOpen] = useState(false);
 
   async function openIssue(number: number) {
     setLoadingIssue(number);
-    const posts = await fetchMagazineIssuePosts(number);
+    const { posts, coverUrl } = await fetchMagazineIssue(number);
     setLoadingIssue(null);
-    if (posts.length > 0) setOpenPosts(posts);
+    if (posts.length > 0) {
+      setOpenCover(coverUrl);
+      setOpenPosts(posts);
+    }
   }
 
   return (
@@ -111,7 +115,15 @@ export default function MagazinePage() {
       </Box>
 
       {/* Fullscreen flipbook of the chosen edition */}
-      {openPosts && <MagazineModal isOpen onClose={() => setOpenPosts(null)} posts={openPosts} preserveOrder />}
+      {openPosts && (
+        <MagazineModal
+          isOpen
+          onClose={() => setOpenPosts(null)}
+          posts={openPosts}
+          preserveOrder
+          zineCover={openCover ?? undefined}
+        />
+      )}
       {/* Fallback: community magazine when no edition is published */}
       {communityOpen && (
         <MagazineModal

--- a/components/shared/MagazineModal.tsx
+++ b/components/shared/MagazineModal.tsx
@@ -83,7 +83,7 @@ const MagazineModal = React.memo(function MagazineModal({
   // Community/blog magazine (no explicit posts, no profile user): show the
   // curated edition the ops portal published, falling back to the live feed.
   const isCommunity = posts === undefined && !hiveUsername;
-  const { curated, loaded } = useCuratedMagazine(isCommunity);
+  const { curated, coverUrl: curatedCover, loaded } = useCuratedMagazine(isCommunity);
 
   // If posts are provided (profile view), use them directly.
   // Community view → curated edition (or fallback). Otherwise tag/query.
@@ -104,7 +104,7 @@ const MagazineModal = React.memo(function MagazineModal({
     }
     if (isCommunity) {
       if (!loaded) return { posts: [], isLoading: true };
-      if (curated && curated.length > 0) return { posts: curated, preserveOrder: true };
+      if (curated && curated.length > 0) return { posts: curated, preserveOrder: true, zineCover: curatedCover ?? undefined };
       // no published edition → fall back to the live community feed below
     }
     return {
@@ -124,6 +124,7 @@ const MagazineModal = React.memo(function MagazineModal({
     userLocation,
     isCommunity,
     curated,
+    curatedCover,
     loaded,
   ]);
 

--- a/hooks/useCuratedMagazine.ts
+++ b/hooks/useCuratedMagazine.ts
@@ -7,7 +7,7 @@ import { Discussion } from "@hiveio/dhive";
 //     flipbook's Discussion shape. Used by the blog MagazineModal + as the
 //     default preview. Falls back to the community feed when nothing published.
 //   useMagazineIssues() — the accumulating archive (covers) for the selector.
-//   fetchMagazineIssuePosts(number) — one edition's posts (for opening a cover).
+//   fetchMagazineIssue(number) — one edition (posts + cover) for opening it.
 const MAGAZINE_API =
   process.env.NEXT_PUBLIC_MAGAZINE_API || "https://skatehive.reelflip.com";
 
@@ -47,8 +47,9 @@ function mapPortalPosts(raw: unknown): Discussion[] {
   );
 }
 
-export function useCuratedMagazine(enabled: boolean = true): { curated: Discussion[] | null; loaded: boolean } {
+export function useCuratedMagazine(enabled: boolean = true): { curated: Discussion[] | null; coverUrl: string | null; loaded: boolean } {
   const [curated, setCurated] = useState<Discussion[] | null>(null);
+  const [coverUrl, setCoverUrl] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
@@ -62,7 +63,10 @@ export function useCuratedMagazine(enabled: boolean = true): { curated: Discussi
       .then((data) => {
         if (!live) return;
         const mapped = mapPortalPosts(data?.posts);
-        if (mapped.length > 0) setCurated(mapped);
+        if (mapped.length > 0) {
+          setCurated(mapped);
+          setCoverUrl(data?.issue?.coverUrl ?? null);
+        }
         setLoaded(true);
       })
       .catch(() => {
@@ -73,7 +77,7 @@ export function useCuratedMagazine(enabled: boolean = true): { curated: Discussi
     };
   }, [enabled]);
 
-  return { curated, loaded };
+  return { curated, coverUrl, loaded };
 }
 
 /** The accumulating published-edition archive (newest first) for the cover selector. */
@@ -101,14 +105,14 @@ export function useMagazineIssues(): { issues: MagazineIssueSummary[]; loaded: b
   return { issues, loaded };
 }
 
-/** Posts of a specific published edition (for opening a chosen cover). */
-export async function fetchMagazineIssuePosts(number: number): Promise<Discussion[]> {
+/** Posts + cover of a specific published edition (for opening a chosen cover). */
+export async function fetchMagazineIssue(number: number): Promise<{ posts: Discussion[]; coverUrl: string | null }> {
   try {
     const r = await fetch(`${MAGAZINE_API}/api/magazine/issue?project=skatehive&number=${number}`);
-    if (!r.ok) return [];
+    if (!r.ok) return { posts: [], coverUrl: null };
     const data = await r.json();
-    return mapPortalPosts(data?.posts);
+    return { posts: mapPortalPosts(data?.posts), coverUrl: data?.issue?.coverUrl ?? null };
   } catch {
-    return [];
+    return { posts: [], coverUrl: null };
   }
 }


### PR DESCRIPTION
The flipbook cover page reads `props.zineCover`, but curated editions only passed `posts` — so they always showed the default cover, ignoring the `coverUrl` set per edition in the ops portal.

Now the edition's cover flows through:
- `useCuratedMagazine()` also returns `coverUrl`; `fetchMagazineIssue(number)` returns `{ posts, coverUrl }`.
- `MagazineModal` (community branch) and the `/magazine` cover selector pass `zineCover`.

So the active edition (blog modal) and any edition opened from a cover now render **their own cover** on the flipbook's first page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)