### PR TITLE
fix(magazine): back-cover flip animation (detached/dislocated last page)

### DIFF
--- a/components/shared/Magazine.tsx
+++ b/components/shared/Magazine.tsx
@@ -120,6 +120,12 @@ const retroBoxShadow = (theme: any) =>
 
 const backCoverStyles = (theme: any) => ({
   ...pageStyles(theme),
+  // Full-bleed like the front cover — without an explicit size the page-flip
+  // engine measures this page short (minHeight only), so the last page looked
+  // detached/dislocated mid-animation.
+  width: "100%",
+  height: "100%",
+  overflow: "hidden",
   background: `linear-gradient(120deg, ${theme.colors.primary} 60%, ${theme.colors.accent} 100%)`,
   color: theme.colors.text,
   justifyContent: "center",
@@ -127,7 +133,18 @@ const backCoverStyles = (theme: any) => ({
   backgroundImage:
     "url(https://media1.giphy.com/media/9ZsHm0z5QwSYpV7g01/giphy.gif?cid=6c09b952uxaerotyqa9vct5pkiwvar6l6knjgsctieeg0sh1&ep=v1_gifs_search&rid=giphy.gif&ct=g)",
   backgroundSize: "cover",
-  boxShadow: "0 8px 32px 0 rgba(179,18,23,0.25)",
+  // Tight outline like the front cover — a large offset drop-shadow renders
+  // outside the page bounds and reads as a "floating" page during the flip.
+  boxShadow: retroBoxShadow(theme),
+});
+
+// Blank filler page: in landscape (two-page spread) the flip engine needs an
+// EVEN page count — with an odd count the last sheet has only one face and the
+// back cover visibly disconnects while flipping. Inserted before the back cover.
+const fillerPageStyles = (theme: any) => ({
+  ...pageStyles(theme),
+  justifyContent: "center",
+  alignItems: "center",
 });
 
 export interface MagazineProps {
@@ -571,6 +588,16 @@ export default function Magazine(props: MagazineProps) {
               </Box>
             );
           })}
+          {/* Even-ize the page count (cover + posts + back cover) so the back
+              cover is always the BACK face of the last sheet — an odd count
+              left it dangling and broke the flip animation. */}
+          {(filteredPosts.length + 2) % 2 === 1 && (
+            <Box sx={fillerPageStyles(theme)}>
+              <Text color={theme.colors.muted} fontSize="sm">
+                — fim da edição —
+              </Text>
+            </Box>
+          )}
           <Box sx={backCoverStyles(theme)}>
             <Heading color={theme.colors.primary}>Back Cover</Heading>
             <Text color={theme.colors.text}>Last Page</Text>


### PR DESCRIPTION
## Problem
Flipping to the back cover looked broken — the last page detached from the book and shifted position mid-animation.

## Causes + fixes
1. **Back cover had no explicit size** (only `pageStyles`' `minHeight: 400`), unlike the front cover (`width/height 100%`). The flip engine measured the page short → detached/dislocated rendering. Now full-bleed `100%` + `overflow: hidden`, and the large offset drop-shadow (renders outside the page bounds → "floating" look) is replaced with the same tight retro outline the front cover uses.
2. **Odd page count in two-page spread mode.** In landscape the engine pairs pages into sheets; with `cover + N posts + back cover` odd, the last sheet had a single face and the back cover dangled during the flip. A blank *"— fim da edição —"* filler page is inserted before the back cover whenever the count is odd, so the back cover is always the back face of the last sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)