### PR TITLE
fix(magazine): flipbook crash on even-page editions (cloneElement null)

### DIFF
--- a/components/shared/Magazine.tsx
+++ b/components/shared/Magazine.tsx
@@ -485,7 +485,7 @@ export default function Magazine(props: MagazineProps) {
               )}
             </Box>
           </Box>
-          {filteredPosts.map((post: Discussion, index) => {
+          {[...filteredPosts.map((post: Discussion, index) => {
             const isLeftPage = index % 2 === 0;
             const pageBorderRadius = isLeftPage
               ? "16px 0 0 0px"
@@ -587,17 +587,20 @@ export default function Magazine(props: MagazineProps) {
                 </Box>
               </Box>
             );
-          })}
-          {/* Even-ize the page count (cover + posts + back cover) so the back
-              cover is always the BACK face of the last sheet — an odd count
-              left it dangling and broke the flip animation. */}
-          {(filteredPosts.length + 2) % 2 === 1 && (
-            <Box sx={fillerPageStyles(theme)}>
+          }),
+          // Even-ize the page count (cover + posts + back cover) so the back
+          // cover is the BACK face of the last sheet. Kept INSIDE the array and
+          // filtered — never a bare `&&`/falsy child, because the flip engine
+          // clones every child and React.Children.map hands cloneElement(null)
+          // for a null/false child, which throws.
+          (filteredPosts.length + 2) % 2 === 1 ? (
+            <Box key="filler" sx={fillerPageStyles(theme)}>
               <Text color={theme.colors.muted} fontSize="sm">
                 — fim da edição —
               </Text>
             </Box>
-          )}
+          ) : null,
+          ].filter(Boolean)}
           <Box sx={backCoverStyles(theme)}>
             <Heading color={theme.colors.primary}>Back Cover</Heading>
             <Text color={theme.colors.text}>Last Page</Text>


### PR DESCRIPTION
## Problem
Opening some curated magazine editions (e.g. **#3**) crashed with:

> Error: The argument must be a React element, but you passed null. at cloneElement …

## Cause
The page-count "even-izer" filler was rendered as a bare `{cond && <Box/>}`
**direct child** of `HTMLFlipBook`. When the condition is false — editions with
an **even** filtered-post count — that leaves a `false` in the flipbook's
children array. `react-pageflip` clones every child via `React.Children.map`,
which **does invoke the callback with `null`** for null/false/undefined
children, so `cloneElement(null)` throws and the whole edition fails to render.

Odd-count editions happened to render the filler (a real element), so they
worked — which is why #1 was fine and #3 wasn't.

## Fix
Move the filler **inside** the posts array and `.filter(Boolean)` it, so the
flipbook never receives a falsy child. No behavioural change to the pagination
itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved how magazine pages are assembled so the filler page is included more reliably alongside post pages.
  - Updated page rendering to handle the final page layout more consistently, reducing the chance of missing or misordered content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->