### PR TITLE
ci: move type-check + lint out of the Vercel build into GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+# Type-checking and linting moved OUT of the Vercel build (next.config.mjs sets
+# typescript.ignoreBuildErrors + eslint.ignoreDuringBuilds to keep deploys fast).
+# These jobs are the safety net that used to run inside `next build`.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  type-check:
+    name: Type check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run type-check
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run lint

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -56,7 +56,14 @@ const nextConfig = {
     compress: true,
     poweredByHeader: false,
     reactStrictMode: true,
-    
+
+    // Type-checking and linting run in CI (GitHub Actions), NOT during the
+    // Vercel build. That build-time `tsc` + ESLint pass was the dominant deploy
+    // cost (~10 min of a ~12 min deploy); moving it to CI cuts deploys to ~2 min
+    // without losing the safety net — see .github/workflows/ci.yml.
+    typescript: { ignoreBuildErrors: true },
+    eslint: { ignoreDuringBuilds: true },
+
     // Performance optimizations
     compiler: {
         removeConsole: process.env.NODE_ENV === 'production' ? {


### PR DESCRIPTION
## Why
Deploys were taking ~11–12 min. Build-log breakdown for a recent deploy:

| Phase | Time |
|---|---|
| Clone + restore cache | ~4s |
| Install deps (pnpm, cache hit) | 1.7s |
| Compile (`next build`) | **86s** |
| **Linting + checking validity of types** | **~10 min** ← the cost |

The dominant cost was the project-wide `tsc` + ESLint pass that `next build`
runs. On a large web3 codebase (Chakra, viem/wagmi, dhive) on a 4-core builder,
that pass is slow and swingy (explains why deploys ranged 4–11 min).

## What
- `next.config.mjs`: `typescript.ignoreBuildErrors: true` + `eslint.ignoreDuringBuilds: true`.
  Type **errors don't affect the emitted JS**, so the runtime output is unchanged —
  the build just stops blocking on them.
- New `.github/workflows/ci.yml`: runs `pnpm type-check` and `pnpm lint` (the same
  checks) in parallel on every PR and push to `main`.

Net effect: deploys drop from ~12 min to ~2 min; type/lint safety is preserved,
just enforced in CI instead of inside the deploy.

> Tip: to make the checks blocking, add them as required status checks in branch
> protection for `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)