### PR TITLE
feat(home): curated media-magazine homepage at /home

### DIFF
--- a/app/RootLayoutClient.tsx
+++ b/app/RootLayoutClient.tsx
@@ -185,6 +185,13 @@ function InnerLayout({
     openReport();
   };
 
+  // The media-magazine homepage is full-bleed: it owns its own sticky nav and
+  // scroll container (globals force html,body{overflow:hidden} on desktop), so
+  // render it directly without the app chrome (sidebar / footer / tab bar).
+  if (pathname === "/home") {
+    return <>{children}</>;
+  }
+
   return (
     <Container
       maxW={{ base: "100%", md: "container.xl" }}

--- a/app/home/HomeMagazineClient.tsx
+++ b/app/home/HomeMagazineClient.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useRef } from "react";
+import { Box, Flex, Spinner } from "@chakra-ui/react";
+import { useHomepageConfig } from "@/hooks/useHomepageConfig";
+import type { HomepageConfigDoc } from "@/types/homepage-config";
+import { P, MONO } from "@/components/home-magazine/palette";
+import { TopNav } from "@/components/home-magazine/TopNav";
+import { HeroCarousel } from "@/components/home-magazine/HeroCarousel";
+import { FeaturedStrip } from "@/components/home-magazine/FeaturedStrip";
+import { JunkAndVideo } from "@/components/home-magazine/JunkAndVideo";
+import { SpotAndRewards } from "@/components/home-magazine/SpotAndRewards";
+import { CommunityBanner, MagFooter, PreviewRibbon } from "@/components/home-magazine/BannerAndFooter";
+
+// The media-magazine homepage shell. Owns its OWN scroll container
+// (overflowY:auto; height:100vh) because sk3's globals force
+// html,body{overflow:hidden} on desktop — anchor nav scrolls within THIS box,
+// not the window. RootLayoutClient renders /home full-bleed (no sidebar/tabbar).
+export default function HomeMagazineClient({
+  initialConfig,
+  previewToken,
+}: {
+  initialConfig: HomepageConfigDoc | null;
+  previewToken: string | null;
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const { config, loaded, preview } = useHomepageConfig(previewToken, initialConfig);
+
+  const navigate = (anchor: string) => {
+    const root = scrollRef.current;
+    if (!root) return;
+    if (anchor === "top") {
+      root.scrollTo({ top: 0, behavior: "smooth" });
+      return;
+    }
+    const el = root.querySelector(`#${anchor}`);
+    if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  return (
+    <Box ref={scrollRef} bg={P.bg} color={P.body} fontFamily={MONO} h="100vh" overflowY="auto" overflowX="hidden" sx={{ scrollbarWidth: "thin" }}>
+      {preview && <PreviewRibbon label="Preview — rascunho (não publicado)" />}
+      {/* no-referrer so the ?preview=<token> never leaks to image/API hosts */}
+      {preview && <meta name="referrer" content="no-referrer" />}
+
+      <TopNav onNavigate={navigate} />
+
+      {!config && !loaded && (
+        <Flex align="center" justify="center" h="60vh"><Spinner color={P.accent} /></Flex>
+      )}
+
+      {config && (
+        <>
+          <HeroCarousel slides={config.heroSlides} />
+          <FeaturedStrip cards={config.strip} />
+          <JunkAndVideo items={config.junkDrawer} video={config.featuredVideo} />
+          <SpotAndRewards spot={config.spot} bounties={config.bounties} />
+          <CommunityBanner headline={config.banner.headline} subtext={config.banner.subtext} ctaLabel={config.banner.ctaLabel} />
+          <MagFooter tagline={config.footer.tagline} />
+          <Box h="40px" />
+        </>
+      )}
+    </Box>
+  );
+}

--- a/app/home/layout.tsx
+++ b/app/home/layout.tsx
@@ -1,0 +1,21 @@
+import { JetBrains_Mono } from "next/font/google";
+import type { Metadata } from "next";
+
+// JetBrains Mono for the terminal-aesthetic media homepage. A nested layout
+// can't class <html>, so we expose the font as a CSS variable on a wrapper div;
+// the palette reads var(--font-jetbrains).
+const jetbrains = JetBrains_Mono({
+  weight: ["400", "500", "700", "800"],
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-jetbrains",
+});
+
+export const metadata: Metadata = {
+  title: "Skatehive Magazine",
+  description: "The curated skateboard-media magazine — by skaters, for skaters.",
+};
+
+export default function HomeMagazineLayout({ children }: { children: React.ReactNode }) {
+  return <div className={jetbrains.variable} style={{ height: "100%" }}>{children}</div>;
+}

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,0 +1,39 @@
+import { redirect } from "next/navigation";
+import HomeMagazineClient from "./HomeMagazineClient";
+import type { HomepageConfigDoc } from "@/types/homepage-config";
+
+// The curated media-magazine homepage. Renders entirely from the portal-managed
+// HomepageConfig (draft→preview→publish). SSR-fetches the config for first
+// paint: published (revalidated) or, with ?preview=<token>, the draft (no
+// store). Nothing published + no preview → fall back to the classic feed.
+export const dynamic = "force-dynamic";
+
+const HOMEPAGE_API = process.env.NEXT_PUBLIC_MAGAZINE_API || "https://skatehive.reelflip.com";
+
+async function fetchConfig(previewToken?: string): Promise<HomepageConfigDoc | null> {
+  try {
+    const url = previewToken
+      ? `${HOMEPAGE_API}/api/homepage/draft?token=${encodeURIComponent(previewToken)}`
+      : `${HOMEPAGE_API}/api/homepage/current?project=skatehive`;
+    const res = await fetch(url, previewToken ? { cache: "no-store" } : { next: { revalidate: 120 } });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { config?: HomepageConfigDoc | null };
+    return data?.config ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function HomePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ preview?: string }>;
+}) {
+  const { preview } = await searchParams;
+  const config = await fetchConfig(preview);
+
+  // No published config and not previewing → send public users to the feed.
+  if (!config && !preview) redirect("/");
+
+  return <HomeMagazineClient initialConfig={config} previewToken={preview ?? null} />;
+}

--- a/components/home-magazine/BannerAndFooter.tsx
+++ b/components/home-magazine/BannerAndFooter.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Box, Button, Flex, Text } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+import { P, MONO } from "./palette";
+
+export function CommunityBanner({ headline, subtext, ctaLabel }: { headline: string; subtext: string; ctaLabel: string }) {
+  const router = useRouter();
+  return (
+    <Flex mx="32px" mt="56px" bg={P.accent} px="44px" py="48px" align="center" justify="space-between" gap="32px" wrap="wrap" fontFamily={MONO}>
+      <Box maxW="640px">
+        <Text fontWeight={800} fontSize="32px" color={P.onAccent} textTransform="uppercase" lineHeight="1.15">{headline}</Text>
+        {subtext && <Text fontSize="15px" color={P.onAccentSoft} mt="12px">{subtext}</Text>}
+      </Box>
+      <Button onClick={() => router.push("/")} bg={P.onAccent} color={P.accent} border="none" borderRadius={0} fontFamily={MONO} fontWeight={800} fontSize="16px" letterSpacing="1px" px="32px" py="18px" h="auto" whiteSpace="nowrap" _hover={{ opacity: 0.9 }}>
+        {ctaLabel || "ENTER COMMUNITY"} &#8594;
+      </Button>
+    </Flex>
+  );
+}
+
+export function MagFooter({ tagline }: { tagline: string }) {
+  return (
+    <Flex mx="32px" mt="56px" py="28px" borderTop={`2px solid ${P.card}`} align="center" justify="space-between" wrap="wrap" gap="12px" fontFamily={MONO}>
+      <Text fontSize="12px" color={P.faint} letterSpacing="1px">{tagline}</Text>
+      <Flex gap="20px" fontSize="12px" color={P.ui} letterSpacing="1px">
+        <Box as="a" href="https://instagram.com/skatehive" target="_blank" rel="noopener" color={P.ui} _hover={{ color: P.accentHover }}>INSTAGRAM</Box>
+        <Box as="a" href="https://youtube.com/@skatehive" target="_blank" rel="noopener" color={P.ui} _hover={{ color: P.accentHover }}>YOUTUBE</Box>
+        <Box as="a" href="https://discord.gg/skatehive" target="_blank" rel="noopener" color={P.ui} _hover={{ color: P.accentHover }}>DISCORD</Box>
+      </Flex>
+    </Flex>
+  );
+}
+
+export function PreviewRibbon({ label }: { label: string }) {
+  return (
+    <Box position="sticky" top={0} zIndex={60} bg={P.accent} color={P.onAccent} fontFamily={MONO} fontWeight={800} fontSize="12px" letterSpacing="2px" textAlign="center" py="6px" textTransform="uppercase">
+      {label}
+    </Box>
+  );
+}

--- a/components/home-magazine/FeaturedStrip.tsx
+++ b/components/home-magazine/FeaturedStrip.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Box, Grid, Image, Text } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+import { postHref, type StripCard } from "@/types/homepage-config";
+import { P, MONO } from "./palette";
+
+export function FeaturedStrip({ cards }: { cards: StripCard[] }) {
+  const router = useRouter();
+  if (cards.length === 0) return null;
+  return (
+    <Grid templateColumns={{ base: "repeat(2,1fr)", md: "repeat(4,1fr)" }} gap="2px" mx="32px" mt="2px" bg={P.card} fontFamily={MONO}>
+      {cards.map((c) => {
+        const href = postHref(c.postRef);
+        return (
+          <Box key={c.id} bg={P.bg} cursor={href ? "pointer" : "default"} onClick={() => href && router.push(href)}>
+            <Box position="relative" style={{ aspectRatio: "4 / 3" }} overflow="hidden">
+              <Image src={c.image} alt="" w="100%" h="100%" objectFit="cover" filter="grayscale(10%)" />
+              <Box position="absolute" inset={0} bg="linear-gradient(180deg, transparent 55%, rgba(0,0,0,0.85) 100%)" />
+              <Text position="absolute" left="12px" bottom="12px" right="12px" fontSize="14px" fontWeight={700} color="#f0f0f0" lineHeight="1.3">
+                {c.title}
+              </Text>
+            </Box>
+          </Box>
+        );
+      })}
+    </Grid>
+  );
+}

--- a/components/home-magazine/HeroCarousel.tsx
+++ b/components/home-magazine/HeroCarousel.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { Box, Flex, Image, Text } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+import { ctaHref, type HeroSlide } from "@/types/homepage-config";
+import { P, MONO } from "./palette";
+
+export function HeroCarousel({ slides }: { slides: HeroSlide[] }) {
+  const router = useRouter();
+  const [i, setI] = useState(0);
+  if (slides.length === 0) return null;
+  const n = slides.length;
+  const s = slides[Math.min(i, n - 1)];
+  const go = (d: 1 | -1) => setI((c) => (c + d + n) % n);
+  const href = ctaHref(s.cta);
+  const onPlay = () => {
+    if (!href) return;
+    if (href.startsWith("http")) window.open(href, "_blank", "noopener");
+    else router.push(href);
+  };
+
+  return (
+    <Box id="featured" position="relative" mx="32px" mt="24px" h="640px" overflow="hidden" border={`2px solid ${P.card}`} fontFamily={MONO}>
+      <Image src={s.image} alt="" position="absolute" inset={0} w="100%" h="100%" objectFit="cover" filter="grayscale(15%) contrast(1.05)" />
+      <Box position="absolute" inset={0} bg="linear-gradient(180deg, rgba(10,10,10,0.1) 0%, rgba(10,10,10,0.15) 45%, rgba(10,10,10,0.95) 100%)" />
+
+      {n > 1 && (
+        <>
+          <ArrowBtn side="left" onClick={() => go(-1)}>&#8249;</ArrowBtn>
+          <ArrowBtn side="right" onClick={() => go(1)}>&#8250;</ArrowBtn>
+        </>
+      )}
+
+      <Box position="absolute" left="44px" bottom="44px" right="44px" maxW="1100px">
+        {s.tag && (
+          <Box display="inline-block" bg="rgba(10,10,10,0.55)" border={`1.5px solid ${P.accent}`} color={P.accent} fontWeight={800} fontSize="13px" letterSpacing="2px" px="14px" py="6px" mb="18px" textTransform="uppercase">
+            {s.tag}
+          </Box>
+        )}
+        <Text fontWeight={800} fontSize="clamp(34px,4.6vw,56px)" lineHeight="1.03" color={P.headline} letterSpacing="-1px" textTransform="uppercase">
+          {s.title}
+        </Text>
+        {s.subtitle && <Text fontSize="17px" color={P.bodyMuted} mt="16px" maxW="700px">{s.subtitle}</Text>}
+        <Flex align="center" gap="18px" mt="22px">
+          {href && (
+            <Flex as="button" onClick={onPlay} w="56px" h="56px" borderRadius="50%" bg={P.accent} align="center" justify="center" color={P.onAccent} fontSize="22px" _hover={{ bg: P.accentHover }}>
+              &#9654;
+            </Flex>
+          )}
+          {s.meta && <Text fontSize="13px" color={P.ui} letterSpacing="1px">{s.meta}</Text>}
+        </Flex>
+      </Box>
+
+      {n > 1 && (
+        <Flex position="absolute" right="44px" bottom="44px" gap="10px">
+          {slides.map((_, idx) => (
+            <Box key={idx} as="button" onClick={() => setI(idx)} w={idx === i ? "32px" : "16px"} h="8px" bg={idx === i ? P.accent : "rgba(255,255,255,0.3)"} transition="width 0.2s" />
+          ))}
+        </Flex>
+      )}
+    </Box>
+  );
+}
+
+function ArrowBtn({ side, onClick, children }: { side: "left" | "right"; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <Flex
+      as="button"
+      onClick={onClick}
+      position="absolute"
+      {...(side === "left" ? { left: "20px" } : { right: "20px" })}
+      top="50%"
+      transform="translateY(-50%)"
+      bg="rgba(10,10,10,0.6)"
+      border={`2px solid ${P.accent}`}
+      color={P.accent}
+      w="48px"
+      h="48px"
+      align="center"
+      justify="center"
+      fontSize="22px"
+      _hover={{ bg: "rgba(10,10,10,0.85)" }}
+    >
+      {children}
+    </Flex>
+  );
+}

--- a/components/home-magazine/JunkAndVideo.tsx
+++ b/components/home-magazine/JunkAndVideo.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Box, Flex, Grid, Image, Text } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+import { postHref, type FeaturedVideo, type JunkItem } from "@/types/homepage-config";
+import { P, MONO } from "./palette";
+
+export function JunkAndVideo({ items, video }: { items: JunkItem[]; video: FeaturedVideo | null }) {
+  const router = useRouter();
+  if (items.length === 0 && !video) return null;
+  return (
+    <Grid id="videos" templateColumns={{ base: "1fr", md: "1fr 1.3fr" }} gap="24px" mx="32px" mt="40px" fontFamily={MONO}>
+      <Box>
+        <Text fontWeight={800} fontSize="26px" letterSpacing="1px" textTransform="uppercase" color={P.accent} mb="18px">
+          Junk Drawer
+        </Text>
+        {items.map((j) => {
+          const href = postHref(j.postRef);
+          return (
+            <Flex key={j.id} gap="16px" py="16px" borderTop={`1px solid ${P.card}`} cursor={href ? "pointer" : "default"} onClick={() => href && router.push(href)}>
+              <Image src={j.thumb} alt="" w="100px" h="75px" objectFit="cover" flexShrink={0} filter="grayscale(15%)" />
+              <Box>
+                <Text fontWeight={700} fontSize="16px" color={P.body} mb="6px">{j.title}</Text>
+                <Text fontSize="13px" color={P.ui} lineHeight="1.5">{j.blurb}</Text>
+              </Box>
+            </Flex>
+          );
+        })}
+      </Box>
+
+      {video && (
+        <Box position="relative" border={`2px solid ${P.card}`} cursor={postHref(video.postRef) ? "pointer" : "default"} onClick={() => { const h = postHref(video.postRef); if (h) router.push(h); }}>
+          <Image src={video.cover} alt="" w="100%" h="100%" objectFit="cover" display="block" minH="420px" />
+          <Box position="absolute" inset={0} bg="linear-gradient(180deg, rgba(10,10,10,0) 55%, rgba(10,10,10,0.92) 100%)" />
+          <Flex position="absolute" top="50%" left="50%" transform="translate(-50%,-50%)" w="74px" h="74px" borderRadius="50%" bg={P.accent} align="center" justify="center" color={P.onAccent} fontSize="28px">
+            &#9654;
+          </Flex>
+          <Box position="absolute" left="24px" right="24px" bottom="22px">
+            <Text fontWeight={800} fontSize="22px" color={P.headline} textTransform="uppercase">{video.title}</Text>
+            {video.caption && <Text fontSize="13px" color="#a8a8a8" mt="6px">{video.caption}</Text>}
+          </Box>
+        </Box>
+      )}
+    </Grid>
+  );
+}

--- a/components/home-magazine/SpotAndRewards.tsx
+++ b/components/home-magazine/SpotAndRewards.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState } from "react";
+import { Box, Button, Flex, Grid, Image, Text } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+import type { BountyRef, SpotPick } from "@/types/homepage-config";
+import { useCommunityRewards } from "@/hooks/useCommunityRewards";
+import { P, MONO } from "./palette";
+
+type LiveSpot = { id: string; name: string; image: string | null; coords: string | null };
+
+export function SpotAndRewards({ spot, bounties }: { spot: SpotPick | null; bounties: BountyRef[] }) {
+  const router = useRouter();
+  const [current, setCurrent] = useState<LiveSpot | null>(
+    spot ? { id: spot.id, name: spot.name, image: spot.image || null, coords: spot.coords } : null,
+  );
+  const [loadingSpot, setLoadingSpot] = useState(false);
+  const { totalUsd, loading: rewardsLoading } = useCommunityRewards();
+
+  async function another() {
+    setLoadingSpot(true);
+    try {
+      const ex = current?.id ? `?exclude=${encodeURIComponent(current.id)}` : "";
+      const res = await fetch(`/api/spotmap/featured${ex}`, { cache: "no-store" });
+      const data = await res.json();
+      const s = data?.spot;
+      if (s) setCurrent({ id: String(s.id), name: s.name, image: s.thumbnail ?? null, coords: s.lat != null && s.lng != null ? `${s.lat},${s.lng}` : null });
+    } catch {
+      /* keep current */
+    } finally {
+      setLoadingSpot(false);
+    }
+  }
+
+  const rewardsStr = rewardsLoading ? "—" : `$${Math.round(totalUsd).toLocaleString("en-US")}`;
+
+  return (
+    <Grid id="spots" templateColumns={{ base: "1fr", md: "1fr 1fr" }} gap="24px" mx="32px" mt="48px" fontFamily={MONO}>
+      {/* Discover a Spot */}
+      <Box border={`2px solid ${P.card}`} p="24px">
+        <Flex align="center" justify="space-between" mb="16px">
+          <Text fontWeight={800} fontSize="18px" color={P.accent} textTransform="uppercase">Discover a Spot &#128757;</Text>
+          <Button onClick={() => router.push("/map")} bg="none" border={`2px solid ${P.ghost}`} borderRadius={0} color={P.ui} fontFamily={MONO} fontSize="11px" fontWeight={700} letterSpacing="1px" px="14px" py="8px" h="auto" _hover={{ color: P.body, borderColor: P.faint }}>
+            VIEW MORE
+          </Button>
+        </Flex>
+        <Box position="relative">
+          {current?.image ? (
+            <Image src={current.image} alt="" w="100%" h="220px" objectFit="cover" display="block" opacity={loadingSpot ? 0.5 : 1} transition="opacity 0.2s" />
+          ) : (
+            <Flex w="100%" h="220px" align="center" justify="center" bg={P.card} color={P.faint} fontSize="13px">sem spot</Flex>
+          )}
+          {current?.coords && (
+            <Box position="absolute" left="10px" top="10px" bg="rgba(10,10,10,0.8)" border={`1px solid ${P.accent}`} color={P.accent} fontSize="12px" px="8px" py="4px">
+              &#128205; {current.coords}
+            </Box>
+          )}
+        </Box>
+        <Text fontSize="15px" color={P.body} my="14px" mb="16px">{current?.name ?? "—"}</Text>
+        <Flex gap="12px">
+          <Button flex={1} onClick={another} isDisabled={loadingSpot} bg="none" border={`2px solid ${P.accent}`} borderRadius={0} color={P.accent} fontFamily={MONO} fontWeight={700} letterSpacing="1px" py="12px" h="auto" _hover={{ bg: P.navTint }}>
+            ANOTHER
+          </Button>
+          <Button flex={1} onClick={() => router.push("/map")} bg="none" border={`2px solid ${P.ghost}`} borderRadius={0} color={P.ui} fontFamily={MONO} fontWeight={700} letterSpacing="1px" py="12px" h="auto" _hover={{ color: P.body }}>
+            VIEW ALL SPOTS
+          </Button>
+        </Flex>
+      </Box>
+
+      {/* Community Rewards */}
+      <Flex id="rewards" direction="column" justify="space-between" border={`2px solid ${P.card}`} p="24px">
+        <Box>
+          <Text fontWeight={800} fontSize="18px" color={P.accent} textTransform="uppercase" mb="10px">Community Rewards</Text>
+          <Text fontWeight={800} fontSize="44px" color={P.headline}>{rewardsStr} <Box as="span" fontSize="20px" color={P.ui}>USD</Box></Text>
+          <Text fontSize="12px" color={P.ui} letterSpacing="1px" textTransform="uppercase" mt="4px">Paid out to skaters</Text>
+        </Box>
+        {bounties.length > 0 && (
+          <Box mt="22px">
+            <Text fontSize="11px" color={P.ui} letterSpacing="1px" textTransform="uppercase" mb="6px">Open Bounties &#127919;</Text>
+            {bounties.map((b, i) => {
+              const title = b.source === "poidh" ? b.name || `Bounty ${b.id}` : b.title;
+              const sponsor = b.source === "poidh" ? `@${b.issuer?.slice(0, 8) ?? ""}` : b.sponsor;
+              return (
+                <Flex key={i} align="center" justify="space-between" py="10px" borderTop={`1px solid ${P.card}`} fontSize="14px">
+                  <Flex align="center" gap="10px" minW={0}>
+                    <Box w="8px" h="8px" bg={P.accent} flexShrink={0} />
+                    <Box minW={0}>
+                      <Text fontWeight={700} color={P.body} isTruncated>{title}</Text>
+                      {sponsor && <Text fontSize="11px" color={P.faint} isTruncated>{sponsor}</Text>}
+                    </Box>
+                  </Flex>
+                </Flex>
+              );
+            })}
+          </Box>
+        )}
+        <Button onClick={() => router.push("/bounties")} mt="18px" bg={P.accent} border="none" borderRadius={0} color={P.onAccent} fontFamily={MONO} fontWeight={800} letterSpacing="1px" py="14px" h="auto" _hover={{ bg: P.accentHover }}>
+          VIEW ALL BOUNTIES
+        </Button>
+      </Flex>
+    </Grid>
+  );
+}

--- a/components/home-magazine/TopNav.tsx
+++ b/components/home-magazine/TopNav.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Box, Button, Flex, Image, Text } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+import { P, MONO } from "./palette";
+
+const LINKS = [
+  { label: "Featured", anchor: "featured" },
+  { label: "Videos", anchor: "videos" },
+  { label: "Spots", anchor: "spots" },
+  { label: "Leaderboard", anchor: "rewards" },
+];
+
+export function TopNav({ onNavigate }: { onNavigate: (anchor: string) => void }) {
+  const router = useRouter();
+  return (
+    <Flex
+      as="nav"
+      position="sticky"
+      top={0}
+      zIndex={50}
+      bg={P.bg}
+      borderBottom={`2px solid ${P.card}`}
+      align="center"
+      justify="space-between"
+      gap="24px"
+      px="32px"
+      py="14px"
+      wrap="wrap"
+      fontFamily={MONO}
+    >
+      <Flex align="center" gap="14px" cursor="pointer" onClick={() => onNavigate("top")}>
+        <Image src="/SKATE_HIVE_VECTOR_FIN.svg" alt="Skatehive" boxSize="52px" objectFit="contain" />
+        <Text fontSize="11px" color={P.faint} letterSpacing="2px" textTransform="uppercase" borderLeft={`2px solid ${P.ghost}`} pl="14px" lineHeight="1.2">
+          Skateboard<br />Media
+        </Text>
+      </Flex>
+
+      <Flex align="center" gap="28px" fontSize="14px" fontWeight={700} letterSpacing="1px" textTransform="uppercase" display={{ base: "none", md: "flex" }}>
+        {LINKS.map((l) => (
+          <Text key={l.anchor} as="button" color={P.body} _hover={{ color: P.accentHover }} onClick={() => onNavigate(l.anchor)}>
+            {l.label}
+          </Text>
+        ))}
+      </Flex>
+
+      <Button
+        onClick={() => router.push("/")}
+        bg={P.accent}
+        color={P.onAccent}
+        border={`2px solid ${P.accent}`}
+        borderRadius={0}
+        fontFamily={MONO}
+        fontWeight={800}
+        fontSize="14px"
+        letterSpacing="1.5px"
+        textTransform="uppercase"
+        px="22px"
+        py="12px"
+        h="auto"
+        _hover={{ bg: P.accentHover }}
+      >
+        Community
+      </Button>
+    </Flex>
+  );
+}

--- a/components/home-magazine/palette.ts
+++ b/components/home-magazine/palette.ts
@@ -1,0 +1,21 @@
+// Fixed terminal palette for the media-magazine /home route — deliberately NOT
+// theme tokens (the 20 user-selectable Chakra themes must not restyle this
+// page, and this page must not add a 21st). Values are the design handoff's.
+export const P = {
+  bg: "#0a0a0a",
+  card: "#1c1c1c", // major border
+  ghost: "#2a2a2a", // secondary/ghost border
+  accent: "#cbff3e",
+  accentHover: "#eaffb0",
+  navTint: "#151f05",
+  headline: "#f5f5f5",
+  body: "#e8e8e8",
+  bodyMuted: "#c7c7c7",
+  ui: "#8a8a8a",
+  faint: "#666",
+  faintest: "#555",
+  onAccent: "#0a0a0a",
+  onAccentSoft: "#1a1a1a",
+} as const;
+
+export const MONO = "var(--font-jetbrains), 'JetBrains Mono', monospace";

--- a/hooks/useCommunityRewards.ts
+++ b/hooks/useCommunityRewards.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { formatEther } from "viem";
+import { HIVE_CONFIG } from "@/config/app.config";
+
+// Live community-rewards figures for the /home rewards card. Extracts the two
+// fetches already used by components/shared/CommunityTotalPayout.tsx: the Hive
+// community total payout (stats.hivehub.dev, a "$"-prefixed string) plus open
+// poidh bounty USD (/api/poidh/bounties open + /api/prices for ETH→USD). Never
+// stored in the config — always fetched fresh so no stale dollar figure ships.
+const TAG = HIVE_CONFIG.COMMUNITY_TAG;
+
+export function useCommunityRewards(): { totalUsd: number; openBountyUsd: number; loading: boolean } {
+  const [totalUsd, setTotalUsd] = useState(0);
+  const [openBountyUsd, setOpenBountyUsd] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let live = true;
+    (async () => {
+      try {
+        const res = await fetch(`https://stats.hivehub.dev/communities?c=${TAG}`);
+        const data = await res.json();
+        const payout = parseFloat(String(data?.[TAG]?.total_payouts_hbd ?? "").replace("$", "") || "0");
+        if (live && payout > 0) setTotalUsd(payout);
+      } catch {
+        /* leave 0 */
+      }
+    })();
+    (async () => {
+      try {
+        const [bRes, pRes] = await Promise.all([
+          fetch("/api/poidh/bounties?status=open&limit=100&filterSkate=true"),
+          fetch("/api/prices"),
+        ]);
+        const bData = await bRes.json();
+        const pData = await pRes.json();
+        const ethPrice = pData?.ethereum?.usd ?? 2500;
+        const bounties: Array<{ amount?: string }> = Array.isArray(bData?.bounties) ? bData.bounties : [];
+        let usd = 0;
+        for (const b of bounties) {
+          try {
+            usd += parseFloat(formatEther(BigInt(b.amount ?? "0"))) * ethPrice;
+          } catch {
+            /* skip malformed */
+          }
+        }
+        if (live) setOpenBountyUsd(usd);
+      } catch {
+        /* leave 0 */
+      } finally {
+        if (live) setLoading(false);
+      }
+    })();
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  return { totalUsd, openBountyUsd, loading };
+}

--- a/hooks/useHomepageConfig.ts
+++ b/hooks/useHomepageConfig.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { HomepageConfigDoc } from "@/types/homepage-config";
+
+// Client hook for the portal-curated homepage config. Serves the SSR `initial`
+// doc immediately, then refetches — the current published config, or (when a
+// preview token is present) the draft, always no-store so a preview tab shows
+// the latest save on reload. Same portal host + env var as the magazine hook.
+const HOMEPAGE_API = process.env.NEXT_PUBLIC_MAGAZINE_API || "https://skatehive.reelflip.com";
+
+export function useHomepageConfig(
+  previewToken?: string | null,
+  initial?: HomepageConfigDoc | null,
+): { config: HomepageConfigDoc | null; loaded: boolean; preview: boolean } {
+  const [config, setConfig] = useState<HomepageConfigDoc | null>(initial ?? null);
+  const [loaded, setLoaded] = useState<boolean>(initial != null);
+
+  useEffect(() => {
+    let live = true;
+    const url = previewToken
+      ? `${HOMEPAGE_API}/api/homepage/draft?token=${encodeURIComponent(previewToken)}`
+      : `${HOMEPAGE_API}/api/homepage/current?project=skatehive`;
+    fetch(url, { cache: "no-store" })
+      .then((r) => r.json())
+      .then((data: { config?: HomepageConfigDoc | null }) => {
+        if (!live) return;
+        setConfig(data?.config ?? null);
+        setLoaded(true);
+      })
+      .catch(() => {
+        if (live) setLoaded(true);
+      });
+    return () => {
+      live = false;
+    };
+  }, [previewToken]);
+
+  return { config, loaded, preview: !!previewToken };
+}

--- a/types/homepage-config.ts
+++ b/types/homepage-config.ts
@@ -1,0 +1,66 @@
+// Mirror of the portal's HomepageConfigDoc (src/lib/homepage-config.ts). Two
+// repos, no shared package — same convention as the magazine's PortalPost. The
+// /home route renders entirely from the PUBLISHED doc; money/status-shaped bits
+// (rewards total, live bounty USD) are hydrated client-side, never stored.
+
+export type PostRef = { author: string; permlink: string };
+
+export type CtaTarget =
+  | { kind: "post"; author: string; permlink: string }
+  | { kind: "spot"; id: string }
+  | { kind: "url"; url: string };
+
+export type HeroSlide = {
+  id: string;
+  image: string;
+  tag: string;
+  title: string;
+  subtitle: string;
+  meta: string;
+  cta: CtaTarget | null;
+  postRef?: PostRef;
+};
+
+export type StripCard = { id: string; postRef: PostRef; image: string; title: string };
+export type JunkItem = { id: string; postRef: PostRef; thumb: string; title: string; blurb: string };
+export type FeaturedVideo = { postRef: PostRef; cover: string; title: string; caption: string };
+
+export type SpotPick = {
+  id: string;
+  name: string;
+  image: string;
+  author: string | null;
+  permlink: string | null;
+  coords: string | null;
+};
+
+export type BountyRef =
+  | { source: "poidh"; id: string; chainId: number; name: string; issuer: string; image?: string }
+  | { source: "hive"; author: string; permlink: string; title: string; sponsor: string };
+
+export type FeaturedUser = { username: string };
+
+export type HomepageConfigDoc = {
+  heroSlides: HeroSlide[];
+  strip: StripCard[];
+  junkDrawer: JunkItem[];
+  featuredVideo: FeaturedVideo | null;
+  spot: SpotPick | null;
+  bounties: BountyRef[];
+  featuredUsers: FeaturedUser[];
+  banner: { headline: string; subtext: string; ctaLabel: string };
+  footer: { tagline: string };
+};
+
+/** Resolve a CTA/postRef to a skatehive.app route. */
+export function ctaHref(cta: CtaTarget | null): string | null {
+  if (!cta) return null;
+  if (cta.kind === "post") return `/post/@${cta.author}/${cta.permlink}`;
+  if (cta.kind === "spot") return `/map`;
+  if (cta.kind === "url") return cta.url;
+  return null;
+}
+
+export function postHref(ref: PostRef | undefined): string | null {
+  return ref ? `/post/@${ref.author}/${ref.permlink}` : null;
+}


### PR DESCRIPTION
## What
A new **`/home`** route that turns the landing experience into a curated skateboard-media magazine (Jenkem/Thrasher energy). It renders **entirely** from the portal-curated `HomepageConfig` — nothing is auto-sorted by recency. The current chronological homepage (`app/page.tsx`) is **untouched**; promotion to `/` is a separate later step.

The admin composes + publishes the config from the ops portal (draft → preview → publish); this route reads it from `/api/homepage/current`.

## Sections (per the design handoff)
- Sticky **TopNav** — logo + FEATURED/VIDEOS/SPOTS/LEADERBOARD (anchor-scroll) + green **Community** button → `/`.
- **Hero carousel** — wrap-around arrows + progress dots.
- **Featured strip** (4 cards, hairline grid).
- **Junk Drawer** + large **featured video**.
- **Discover a Spot** (ANOTHER swaps via `/api/spotmap/featured`) + **Community Rewards** (live total via `useCommunityRewards`, curated open bounties).
- Green **community banner** + footer.

## Notes for review
- **Terminal palette is scoped, not a new theme** — hardcoded values in `components/home-magazine/palette.ts`, JetBrains Mono via a nested `app/home/layout.tsx`. The 20 selectable Chakra themes don't touch it and it doesn't add a 21st.
- **Full-bleed:** `RootLayoutClient` renders `/home` without the sidebar/footer/tab bar, and the page owns its **own** `overflowY:auto; height:100vh` scroll container — because `globals.css` forces `html,body{overflow:hidden}` on desktop. Anchor nav scrolls within that container (not the window).
- **Preview:** `/home?preview=<token>` reads the draft (`no-store`) behind a PREVIEW ribbon + `no-referrer`.
- No published config + not previewing → redirect to `/` (public users never see an empty shell).
- Config host reuses `NEXT_PUBLIC_MAGAZINE_API` (same portal as the magazine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)