### PR TITLE
Fix embed poster letterboxing caused by global markdown image styles

### DIFF
--- a/components/markdown/ThreeSpeakPlayer.tsx
+++ b/components/markdown/ThreeSpeakPlayer.tsx
@@ -266,6 +266,7 @@ function ThreeSpeakPoster({
     >
       {poster && (
         <img
+          className="embed-poster"
           src={poster}
           alt=""
           loading="lazy"

--- a/components/markdown/VideoEmbed.tsx
+++ b/components/markdown/VideoEmbed.tsx
@@ -75,6 +75,7 @@ function YouTubeLite({ id: rawId }: { id: string }) {
       }}
     >
       <img
+        className="embed-poster"
         src={posterSrc}
         onError={() =>
           setPosterSrc(`https://img.youtube.com/vi/${id}/hqdefault.jpg`)
@@ -293,6 +294,7 @@ function OdyseeLite({ url }: { url: string }) {
     >
       {posterSrc && (
         <img
+          className="embed-poster"
           src={posterSrc}
           alt=""
           loading="lazy"
@@ -463,6 +465,7 @@ function VimeoLite({ id }: { id: string }) {
     >
       {posterSrc && (
         <img
+          className="embed-poster"
           src={posterSrc}
           alt=""
           loading="lazy"

--- a/styles/markdown.css
+++ b/styles/markdown.css
@@ -251,7 +251,7 @@ html[data-skatehive-theme="gruvbox-nogg"] .post-page .post-prose {
 }
 
 /* Regular image styling - keep existing behavior but ensure centering - exclude mention avatars */
-.markdown-body img:not([src*=".gif"]):not([src*="/giphy.gif"]):not([src*="tenor.com"]):not([src*="giphy.com"]):not([alt*="@"]) {
+.markdown-body img:not([src*=".gif"]):not([src*="/giphy.gif"]):not([src*="tenor.com"]):not([src*="giphy.com"]):not([alt*="@"]):not(.embed-poster) {
   display: block !important;
   margin: 1.5rem auto !important;
   max-width: 100% !important;
@@ -259,6 +259,14 @@ html[data-skatehive-theme="gruvbox-nogg"] .post-page .post-prose {
   border-radius: 4px !important;
   box-shadow: 0 2px 16px rgba(0, 0, 0, 0.12) !important;
 }
+
+/* Video-embed poster images (YouTube/Odysee/Vimeo/3Speak) fill a
+   fixed-aspect button and rely on their inline `height: 100%` +
+   `object-fit: cover`. The general markdown-image rule above would force
+   `height: auto`, collapsing the poster to its natural ratio inside the
+   taller box and exposing the black button background as top/bottom bars —
+   so posters are excluded from it (`:not(.embed-poster)`). object-fit then
+   has real box dimensions to crop against and the poster fills edge-to-edge. */
 
 /* Mention styling for inline user mentions */
 .markdown-body a[href^="/@"] {
@@ -632,7 +640,7 @@ html[data-skatehive-theme="gruvbox-nogg"] .post-page .post-prose {
 }
 
 /* ─── Image frames ───────────────────────────────── */
-.post-prose[data-image-frames="on"] .markdown-body img:not([src*=".gif"]):not([src*="/giphy.gif"]):not([src*="tenor.com"]):not([src*="giphy.com"]):not([alt*="@"]) {
+.post-prose[data-image-frames="on"] .markdown-body img:not([src*=".gif"]):not([src*="/giphy.gif"]):not([src*="tenor.com"]):not([src*="giphy.com"]):not([alt*="@"]):not(.embed-poster) {
   border-radius: var(--pp-image-radius) !important;
   border: var(--pp-image-border) solid color-mix(in srgb, white var(--pp-image-border-tint, 8%), transparent);
   box-shadow: 0 10px 32px rgba(0, 0, 0, calc(var(--pp-image-shadow) * 1.0)) !important;


### PR DESCRIPTION
This PR fixes an issue where video embed posters (YouTube, Odysee, Vimeo, and 3Speak) displayed black bars above and below the thumbnail before playback.

The issue was caused by global markdown image styles overriding the poster image dimensions, preventing `object-fit: cover` from working as intended.

## Root Cause

Global markdown image rules were unintentionally affecting embed poster images:

```css
.markdown-body img:not(...):not([alt*="@"]) {
  height: auto !important;
  margin: 1.5rem auto !important;
}
```

The `height: auto !important` rule overrode the poster image's inline `height: 100%`, causing the image to render at its natural aspect ratio instead of filling the 9:16 container. As a result, the black player background became visible as letterboxing.

This affected all embed providers consistently:

* YouTube
* Odysee
* Vimeo
* 3Speak

## Solution

* Excluded embed poster images from the global markdown image rules using `:not(.embed-poster)`.
* Added `className="embed-poster"` to poster images in:

  * `VideoEmbed.tsx`
  * `ThreeSpeakPlayer.tsx`

With the global override removed, the existing inline styles (`height: 100%` + `object-fit: cover`) work as intended, allowing posters to fill their containers correctly.

## Result

![](https://private-user-images.githubusercontent.com/495887/619765899-e38bec67-87c3-4c56-b97e-f3e965643fad.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3ODM2NDYzMjMsIm5iZiI6MTc4MzY0NjAyMywicGF0aCI6Ii80OTU4ODcvNjE5NzY1ODk5LWUzOGJlYzY3LTg3YzMtNGM1Ni1iOTdlLWYzZTk2NTY0M2ZhZC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjYwNzEwJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI2MDcxMFQwMTEzNDNaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT02ZDNiOGI0MDRkN2RhM2E1NTJmNGQ4Yzk3NjFmMzcxMWJhZjdiODExN2Q2OGYwYmFjZmM5ODU4NGI3Yjc4ZWE4JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZyZXNwb25zZS1jb250ZW50LXR5cGU9aW1hZ2UlMkZwbmcifQ.ho2J5hWX5LqvVfkwMkDyICuz3c5YoWXnN8580PxSlF4)

**Before**

* Portrait video posters rendered at their natural height.
* Black bars appeared above and below the thumbnail.
* Changing `object-fit` had no effect because the image never filled the container.

**After**

* Poster images fill the entire player area.
* Portrait videos crop correctly to match the player dimensions.
* Poster appearance now matches the actual video frame.
* Regular markdown images remain unchanged.

## Notes

This fix only changes styling for embed poster images. Standard images inside markdown posts continue using the existing responsive `height: auto` behavior.

Additionally, verification confirmed that the affected Odysee and YouTube Shorts examples contain genuine portrait video thumbnails, so the issue was not related to the 9:16 aspect-ratio detection but solely to the global CSS override.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video embed poster image styling across supported platforms.
  * Prevented poster images from inheriting general markdown image frames or styles that could disrupt embed layouts.
  * Preserved consistent poster sizing and cropping within video embeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->