### PR TITLE
feat(home): app sidebar becomes the magazine index rail on /home

### DIFF
--- a/app/home/HomeMagazineClient.tsx
+++ b/app/home/HomeMagazineClient.tsx
@@ -4,17 +4,16 @@ import { Box, Flex, Spinner } from "@chakra-ui/react";
 import { useHomepageConfig } from "@/hooks/useHomepageConfig";
 import type { HomepageConfigDoc } from "@/types/homepage-config";
 import { P, MONO } from "@/components/home-magazine/palette";
-import { SideIndex } from "@/components/home-magazine/SideIndex";
 import { HeroCarousel } from "@/components/home-magazine/HeroCarousel";
 import { FeaturedGrid } from "@/components/home-magazine/FeaturedGrid";
 import { JunkAndVideo } from "@/components/home-magazine/JunkAndVideo";
 import { SpotAndRewards } from "@/components/home-magazine/SpotAndRewards";
 import { CommunityBanner, PreviewRibbon } from "@/components/home-magazine/BannerAndFooter";
 
-// Sidebar-index layout: the magazine keeps the app's original Skatehive sidebar
-// (rendered by RootLayoutClient) and, to its right, a fixed 240px index rail +
-// a content column. This flows INSIDE the app's scroll container (no own
-// 100vh/overflow), so the rail sticks and the app chrome stays intact.
+// Magazine content column. The magazine INDEX rail is the app's own Sidebar on
+// /home (see components/layout/Sidebar.tsx → HomeIndexSidebar), so here we only
+// render the content — it flows inside the app's scroll container, beside that
+// rail. The rail's nav anchor-scrolls to the section ids below.
 export default function HomeMagazineClient({
   initialConfig,
   previewToken,
@@ -25,28 +24,22 @@ export default function HomeMagazineClient({
   const { config, loaded, preview } = useHomepageConfig(previewToken, initialConfig);
 
   return (
-    <Box bg={P.bg} color={P.body} fontFamily={MONO} minH="100%">
+    <Box bg={P.bg} color={P.body} fontFamily={MONO} minH="100%" px={{ base: "16px", md: "40px" }} pt="24px" pb="56px">
       {preview && <PreviewRibbon label="Preview — rascunho (não publicado)" />}
       {preview && <meta name="referrer" content="no-referrer" />}
 
-      <Flex align="flex-start">
-        <SideIndex bountyCount={config?.bounties.length ?? 0} />
-
-        <Box flex="1" minW={0} px={{ base: "16px", md: "40px" }} pt="24px" pb="56px">
-          {!config && !loaded && (
-            <Flex align="center" justify="center" h="60vh"><Spinner color={P.accent} /></Flex>
-          )}
-          {config && (
-            <>
-              <HeroCarousel slides={config.heroSlides} />
-              <FeaturedGrid cards={config.strip} />
-              <JunkAndVideo items={config.junkDrawer} video={config.featuredVideo} />
-              <SpotAndRewards spot={config.spot} bounties={config.bounties} />
-              <CommunityBanner headline={config.banner.headline} subtext={config.banner.subtext} ctaLabel={config.banner.ctaLabel} />
-            </>
-          )}
-        </Box>
-      </Flex>
+      {!config && !loaded && (
+        <Flex align="center" justify="center" h="60vh"><Spinner color={P.accent} /></Flex>
+      )}
+      {config && (
+        <>
+          <HeroCarousel slides={config.heroSlides} />
+          <FeaturedGrid cards={config.strip} />
+          <JunkAndVideo items={config.junkDrawer} video={config.featuredVideo} />
+          <SpotAndRewards spot={config.spot} bounties={config.bounties} />
+          <CommunityBanner headline={config.banner.headline} subtext={config.banner.subtext} ctaLabel={config.banner.ctaLabel} />
+        </>
+      )}
     </Box>
   );
 }

--- a/components/home-magazine/FeaturedGrid.tsx
+++ b/components/home-magazine/FeaturedGrid.tsx
@@ -21,9 +21,16 @@ export function FeaturedGrid({ cards }: { cards: StripCard[] }) {
           return (
             <Flex key={c.id} gap="16px" cursor={href ? "pointer" : "default"} onClick={() => href && router.push(href)} align="flex-start">
               <Image src={c.image} alt="" w="120px" h="90px" objectFit="cover" flexShrink={0} filter="grayscale(10%)" />
-              <Text fontWeight={700} fontSize="16px" color={P.body} lineHeight="1.3" _hover={{ color: P.headline }}>
-                {c.title}
-              </Text>
+              <Box minW={0}>
+                {c.category && (
+                  <Text fontSize="11px" fontWeight={800} letterSpacing="1.5px" textTransform="uppercase" color={P.accent} mb="4px">
+                    {c.category}
+                  </Text>
+                )}
+                <Text fontWeight={700} fontSize="16px" color={P.body} lineHeight="1.3" _hover={{ color: P.headline }}>
+                  {c.title}
+                </Text>
+              </Box>
             </Flex>
           );
         })}

--- a/components/home-magazine/HomeIndexSidebar.tsx
+++ b/components/home-magazine/HomeIndexSidebar.tsx
@@ -4,13 +4,14 @@ import { useState } from "react";
 import { Box, Button, Flex, Image, Text } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { useCommunityRewards } from "@/hooks/useCommunityRewards";
+import { useHomepageConfig } from "@/hooks/useHomepageConfig";
 import { P, MONO } from "./palette";
 
-// The magazine's fixed 240px index rail (desktop). Logo + vertical section nav
-// (anchor-scrolls the content), a live "paid to skaters" figure, and a Community
-// CTA + socials pinned to the bottom. Sits INSIDE the app chrome, to the right
-// of the original Skatehive sidebar. Hidden on mobile (the app tab bar covers
-// navigation there).
+// The app's Sidebar renders THIS on /home (see components/layout/Sidebar.tsx) —
+// the magazine index rail becomes the sidebar itself (one rail, matching the
+// design), replacing the normal app nav on that route only. Logo + vertical
+// section nav (anchor-scrolls the content) + live "paid to skaters" + Community
+// CTA + socials. Full-height, dark terminal palette, hidden on mobile.
 const NAV = [
   { label: "Featured", id: "featured" },
   { label: "Videos", id: "videos" },
@@ -18,10 +19,12 @@ const NAV = [
   { label: "Leaderboard", id: "rewards" },
 ];
 
-export function SideIndex({ bountyCount }: { bountyCount: number }) {
+export function HomeIndexSidebar() {
   const router = useRouter();
   const [active, setActive] = useState("featured");
   const { totalUsd, loading } = useCommunityRewards();
+  const { config } = useHomepageConfig(); // published config → open-bounty count
+  const bountyCount = config?.bounties.length ?? 0;
 
   const go = (id: string) => {
     setActive(id);
@@ -30,21 +33,17 @@ export function SideIndex({ bountyCount }: { bountyCount: number }) {
 
   return (
     <Flex
-      as="aside"
+      as="nav"
       direction="column"
-      display={{ base: "none", lg: "flex" }}
-      position="sticky"
-      top={0}
-      alignSelf="flex-start"
-      h="100vh"
+      display={{ base: "none", md: "flex" }}
       w="240px"
       flexShrink={0}
+      h="100vh"
       bg={P.bg}
       borderRight={`2px solid ${P.card}`}
       fontFamily={MONO}
       py="20px"
     >
-      {/* Logo */}
       <Flex align="center" gap="12px" px="20px" pb="20px" cursor="pointer" onClick={() => go("featured")}>
         <Image src="/SKATE_HIVE_VECTOR_FIN.svg" alt="Skatehive" boxSize="44px" objectFit="contain" />
         <Text fontSize="11px" color={P.faint} letterSpacing="2px" textTransform="uppercase" lineHeight="1.3">
@@ -52,7 +51,6 @@ export function SideIndex({ bountyCount }: { bountyCount: number }) {
         </Text>
       </Flex>
 
-      {/* Vertical nav */}
       <Flex direction="column" mt="6px">
         {NAV.map((n) => {
           const on = active === n.id;
@@ -79,7 +77,6 @@ export function SideIndex({ bountyCount }: { bountyCount: number }) {
         })}
       </Flex>
 
-      {/* Paid-to-skaters box */}
       <Box mx="20px" mt="24px" p="16px" border={`1px solid ${P.card}`}>
         <Text fontSize="10px" color={P.ui} letterSpacing="1px" textTransform="uppercase" mb="6px">Paid to skaters</Text>
         <Text fontWeight={800} fontSize="24px" color={P.accent} lineHeight="1.1">
@@ -90,7 +87,6 @@ export function SideIndex({ bountyCount }: { bountyCount: number }) {
 
       <Box flex={1} />
 
-      {/* Community CTA + socials */}
       <Box px="20px">
         <Button
           onClick={() => router.push("/")}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -32,6 +32,7 @@ import { useTheme } from "@/app/themeProvider";
 import { useNotifications } from "@/contexts/NotificationContext";
 import SidebarLogo from "../graphics/SidebarLogo";
 import AuthButton from "./AuthButton";
+import { HomeIndexSidebar } from "../home-magazine/HomeIndexSidebar";
 import { useTranslations } from "@/contexts/LocaleContext";
 import { useSoundSettings } from "@/contexts/SoundSettingsContext";
 
@@ -267,6 +268,11 @@ export default function Sidebar() {
 
   if (!isClientMounted) {
     return null;
+  }
+
+  // On the curated media homepage, the sidebar IS the magazine index rail.
+  if (pathname === "/home") {
+    return <HomeIndexSidebar />;
   }
 
   return (

--- a/types/homepage-config.ts
+++ b/types/homepage-config.ts
@@ -21,7 +21,7 @@ export type HeroSlide = {
   postRef?: PostRef;
 };
 
-export type StripCard = { id: string; postRef: PostRef; image: string; title: string };
+export type StripCard = { id: string; postRef: PostRef; image: string; title: string; category?: string };
 export type JunkItem = { id: string; postRef: PostRef; thumb: string; title: string; blurb: string };
 export type FeaturedVideo = { postRef: PostRef; cover: string; title: string; caption: string };
 


### PR DESCRIPTION
Per the reference, `/home` has a **single** left rail. The app's own `Sidebar` now renders the **magazine index** on `/home` (`HomeIndexSidebar`) — logo, vertical FEATURED/VIDEOS/SPOTS/LEADERBOARD nav (active + anchor-scroll), live PAID TO SKATERS + open-bounty count, Community CTA + IG/YT/DISCORD — replacing the normal app nav on that route only (one-line `pathname === "/home"` branch in `Sidebar.tsx`).

- Removed the standalone `SideIndex` + its extra column; `HomeMagazineClient` is now just the content column beside the sidebar-rail.
- FEATURED cards render the optional **category eyebrow** (green, above the title) from the new portal `category` field; mirrored into the sk3 type.

So `/home` is now `[Skatehive sidebar = magazine index] · [content]` — one rail, matching the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)