### PR TITLE
Fix Odysee video previews and playback in profile Snaps

### DIFF
--- a/components/profile/SnapModal.tsx
+++ b/components/profile/SnapModal.tsx
@@ -118,6 +118,16 @@ const SnapModal = ({
   );
   const currentMedia = allMedia[currentMediaIndex];
   const isVideo = currentSnap.media.videos.includes(currentMedia);
+  // Odysee `$/embed/…` URLs are HTML embed pages — they must be played in an
+  // <iframe>, not the IPFS/MP4 VideoRenderer (which would 404 the poster and
+  // fail to load the source).
+  const isOdyseeEmbed = (() => {
+    try {
+      return /(^|\.)odysee\.com$/i.test(new URL(currentMedia || "").hostname);
+    } catch {
+      return false;
+    }
+  })();
   const { src: mediaSrc, onError: onMediaError } = useHeicFallback(currentMedia || "");
 
   const nextMedia = useCallback(() => {
@@ -334,11 +344,23 @@ const SnapModal = ({
                   },
                 }}
               >
-                <VideoRenderer
-                  src={currentMedia}
-                  loop
-                  skipThumbnailLoad={true}
-                />
+                {isOdyseeEmbed ? (
+                  <Box
+                    as="iframe"
+                    src={currentMedia}
+                    width="100%"
+                    height="100%"
+                    border="none"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowFullScreen
+                  />
+                ) : (
+                  <VideoRenderer
+                    src={currentMedia}
+                    loop
+                    skipThumbnailLoad={true}
+                  />
+                )}
               </Box>
             ) : (
               <Image

--- a/components/profile/SnapModal.tsx
+++ b/components/profile/SnapModal.tsx
@@ -348,6 +348,7 @@ const SnapModal = ({
                   <Box
                     as="iframe"
                     src={currentMedia}
+                    title={`Odysee video by @${currentSnap.author}`}
                     width="100%"
                     height="100%"
                     border="none"

--- a/components/profile/SnapsGrid.tsx
+++ b/components/profile/SnapsGrid.tsx
@@ -103,7 +103,10 @@ export default function SnapsGrid({ username, hasSoftSnaps }: SnapsGridProps) {
       const videoUrls = snaps
         .filter((snap) => snap.media.videos.length > 0)
         .slice(0, 6) // Only preload first 6 videos
-        .map((snap) => snap.media.videos[0]);
+        .map((snap) => snap.media.videos[0])
+        // Skip Odysee embed pages — preloadThumbnails resolves posters via the
+        // IPFS metadata route, which 404s for platform embed URLs.
+        .filter((url) => !/(^|\.)odysee\.com/i.test(url));
 
       if (videoUrls.length > 0) {
         preloadThumbnails(videoUrls).catch((error) => {

--- a/components/profile/VideoPreview.tsx
+++ b/components/profile/VideoPreview.tsx
@@ -8,7 +8,115 @@ interface VideoPreviewProps {
     onClick?: () => void;
 }
 
+// Odysee `$/embed/…` URLs are HTML embed pages, not media files, so a raw
+// <video src> can't play them (and the poster preload 404s against the IPFS
+// metadata route). For the grid card we just need a static poster; the modal
+// plays it in an <iframe>. Detected here so this component can branch to an
+// <img> poster (og:image via /api/odysee-thumbnail) instead of a <video>.
+const isOdyseeUrl = (url: string) => {
+    try {
+        return /(^|\.)odysee\.com$/i.test(new URL(url).hostname);
+    } catch {
+        return false;
+    }
+};
+
 export default function VideoPreview({ src, onClick }: VideoPreviewProps) {
+    if (isOdyseeUrl(src)) {
+        return <OdyseeVideoPreview src={src} onClick={onClick} />;
+    }
+    return <FileVideoPreview src={src} onClick={onClick} />;
+}
+
+// Shared play-icon overlays used by both preview variants.
+function PlayOverlays({ showCenter }: { showCenter: boolean }) {
+    return (
+        <>
+            <Box
+                position="absolute"
+                bottom={2}
+                right={2}
+                bg="blackAlpha.700"
+                borderRadius="full"
+                p={1}
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+            >
+                <Icon as={FaPlay} color="white" boxSize={3} />
+            </Box>
+            {showCenter && (
+                <Box
+                    position="absolute"
+                    top="50%"
+                    left="50%"
+                    transform="translate(-50%, -50%)"
+                    bg="blackAlpha.600"
+                    borderRadius="full"
+                    p={3}
+                    display="flex"
+                    alignItems="center"
+                    justifyContent="center"
+                >
+                    <Icon as={FaPlay} color="white" boxSize={6} />
+                </Box>
+            )}
+        </>
+    );
+}
+
+// Odysee grid card: static og:image poster + play overlay. Clicking bubbles
+// to onClick (opens SnapModal, which plays the embed in an <iframe>).
+function OdyseeVideoPreview({ src, onClick }: VideoPreviewProps) {
+    const [poster, setPoster] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        fetch(`/api/odysee-thumbnail?url=${encodeURIComponent(src)}`)
+            .then((r) => (r.ok ? r.json() : null))
+            .then((j) => {
+                if (!cancelled && typeof j?.thumbnail === "string") {
+                    setPoster(j.thumbnail);
+                }
+            })
+            .catch(() => {
+                /* no poster — fall back to the black card + play icon */
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [src]);
+
+    return (
+        <Box
+            position="relative"
+            width="100%"
+            height="100%"
+            cursor="pointer"
+            bg="black"
+            onClick={onClick}
+            _hover={{ transform: "scale(1.02)", transition: "transform 0.2s" }}
+        >
+            {poster && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                    src={poster}
+                    alt=""
+                    loading="lazy"
+                    style={{
+                        width: "100%",
+                        height: "100%",
+                        objectFit: "cover",
+                        borderRadius: "inherit",
+                    }}
+                />
+            )}
+            <PlayOverlays showCenter={!poster} />
+        </Box>
+    );
+}
+
+function FileVideoPreview({ src, onClick }: VideoPreviewProps) {
     const videoRef = useRef<HTMLVideoElement>(null);
     const [isLoaded, setIsLoaded] = useState(false);
     const [hasError, setHasError] = useState(false);
@@ -88,38 +196,7 @@ export default function VideoPreview({ src, onClick }: VideoPreviewProps) {
                 }}
             />
 
-            {/* Play icon overlay */}
-            <Box
-                position="absolute"
-                bottom={2}
-                right={2}
-                bg="blackAlpha.700"
-                borderRadius="full"
-                p={1}
-                display="flex"
-                alignItems="center"
-                justifyContent="center"
-            >
-                <Icon as={FaPlay} color="white" boxSize={3} />
-            </Box>
-
-            {/* Loading/Error state */}
-            {(!isLoaded || hasError) && (
-                <Box
-                    position="absolute"
-                    top="50%"
-                    left="50%"
-                    transform="translate(-50%, -50%)"
-                    bg="blackAlpha.600"
-                    borderRadius="full"
-                    p={3}
-                    display="flex"
-                    alignItems="center"
-                    justifyContent="center"
-                >
-                    <Icon as={FaPlay} color="white" boxSize={6} />
-                </Box>
-            )}
+            <PlayOverlays showCenter={!isLoaded || hasError} />
         </Box>
     );
 }


### PR DESCRIPTION
This PR fixes Odysee videos in the profile Snaps grid (`/user/<name>`), where embeds failed to display thumbnails and could not be played from the modal.

Previously, Odysee embed URLs were treated as direct video files, causing previews and playback to fail.

## Root Cause

The media extraction pipeline includes every `<iframe src>` in the `videos[]` array. For Odysee, this produces an `$ /embed/...` URL, which is an HTML embed page rather than a playable video file.

As a result:

* **SnapsGrid → VideoPreview**

  * Attempted to render the embed URL in a native `<video>` element.
  * Poster preloading requested `/api/pinata/metadata/<odysee-url>`, resulting in unnecessary 404s.

* **SnapModal**

  * Passed the embed URL to `VideoRenderer`, which expects a direct video source (IPFS/MP4/HLS).
  * Playback failed with **"Video failed to load."**

## Solution

Added Odysee-specific handling at the rendering layer while leaving media extraction unchanged.

### Changes

* **`VideoPreview.tsx`**

  * Added a dedicated `OdyseeVideoPreview` component.
  * Retrieves the poster through the existing `/api/odysee-thumbnail` endpoint.
  * Displays the thumbnail using `object-fit: cover` with a play overlay.
  * Clicking the preview continues to open the modal.

* **`SnapModal.tsx`**

  * Odysee embeds are now rendered inside an `<iframe>` instead of `VideoRenderer`.

* **`SnapsGrid.tsx`**

  * Excluded Odysee embed URLs from thumbnail preloading to avoid unnecessary Pinata metadata requests and 404 responses.

## Result

* Odysee videos now display thumbnails correctly in the profile Snaps grid.
* Clicking an Odysee Snap opens a playable embedded video.
* Unnecessary Pinata metadata requests for Odysee embeds have been eliminated.
* Existing behavior for direct video files remains unchanged.

## Validation

* ✅ `tsc --noEmit` passes on all modified files.
* ✅ Confirmed Odysee embed URLs are iframe-embeddable.
* ✅ Confirmed `/api/odysee-thumbnail` returns the expected `og:image` poster.
* ✅ Poster images fill the preview card correctly using `object-fit: cover`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Odysee support across profile snaps with dedicated previews.
  * Odysee links now render embedded playback directly in the snap modal.
  * Odysee video previews use thumbnail images when available, with a clear fallback card when not.
  * Standard video previews keep existing loading/error behavior and play overlays.

* **Bug Fixes**
  * Fixed thumbnail preloading to exclude Odysee embed-page URLs, preventing incorrect thumbnail behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->