### PR TITLE
feat(home): Discover a Spot is the location-based widget

### DIFF
--- a/app/home/HomeMagazineClient.tsx
+++ b/app/home/HomeMagazineClient.tsx
@@ -3,6 +3,7 @@
 import { Box, Flex, Spinner } from "@chakra-ui/react";
 import { useHomepageConfig } from "@/hooks/useHomepageConfig";
 import type { HomepageConfigDoc } from "@/types/homepage-config";
+import type { FeaturedSpot } from "@/lib/spotmap/featured";
 import { MONO } from "@/components/home-magazine/palette";
 import { HeroCarousel } from "@/components/home-magazine/HeroCarousel";
 import { FeaturedGrid } from "@/components/home-magazine/FeaturedGrid";
@@ -18,9 +19,11 @@ import { CommunityBanner, PreviewRibbon } from "@/components/home-magazine/Banne
 export default function HomeMagazineClient({
   initialConfig,
   previewToken,
+  initialFeaturedSpot = null,
 }: {
   initialConfig: HomepageConfigDoc | null;
   previewToken: string | null;
+  initialFeaturedSpot?: FeaturedSpot | null;
 }) {
   const { config, loaded, preview } = useHomepageConfig(previewToken, initialConfig);
 
@@ -37,7 +40,7 @@ export default function HomeMagazineClient({
           <HeroCarousel slides={config.heroSlides} />
           <FeaturedGrid cards={config.strip} />
           <JunkAndVideo items={config.junkDrawer} video={config.featuredVideo} />
-          <SpotAndRewards spot={config.spot} bounties={config.bounties} />
+          <SpotAndRewards initialFeaturedSpot={initialFeaturedSpot} bounties={config.bounties} />
           <CommunityBanner headline={config.banner.headline} subtext={config.banner.subtext} ctaLabel={config.banner.ctaLabel} />
         </>
       )}

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import HomeMagazineClient from "./HomeMagazineClient";
 import type { HomepageConfigDoc } from "@/types/homepage-config";
+import { getInitialFeaturedSpot } from "@/lib/spotmap/featured";
 
 // The curated media-magazine homepage. Renders entirely from the portal-managed
 // HomepageConfig (draft→preview→publish). SSR-fetches the config for first
@@ -46,5 +47,14 @@ export default async function HomePage({
   if (result.status === "empty" && !preview) redirect("/");
 
   const initialConfig = result.status === "ok" ? result.config : null;
-  return <HomeMagazineClient initialConfig={initialConfig} previewToken={preview ?? null} />;
+  // SSR the location-based featured spot (same as the classic homepage) so the
+  // "Discover a Spot" widget paints without a skeleton flash.
+  const initialFeaturedSpot = await getInitialFeaturedSpot().catch(() => null);
+  return (
+    <HomeMagazineClient
+      initialConfig={initialConfig}
+      previewToken={preview ?? null}
+      initialFeaturedSpot={initialFeaturedSpot}
+    />
+  );
 }

--- a/components/home-magazine/SpotAndRewards.tsx
+++ b/components/home-magazine/SpotAndRewards.tsx
@@ -1,66 +1,20 @@
 "use client";
 
-import { useState } from "react";
-import { Box, Button, Flex, Grid, Image, Text } from "@chakra-ui/react";
+import { Box, Button, Flex, Grid, Text } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
-import type { BountyRef, SpotPick } from "@/types/homepage-config";
+import type { BountyRef } from "@/types/homepage-config";
+import type { FeaturedSpot } from "@/lib/spotmap/featured";
+import SpotNearYou from "@/components/homepage/SpotNearYou";
 import { P, MONO } from "./palette";
 
-type LiveSpot = { id: string; name: string; image: string | null; coords: string | null };
-
-export function SpotAndRewards({ spot, bounties }: { spot: SpotPick | null; bounties: BountyRef[] }) {
+export function SpotAndRewards({ initialFeaturedSpot, bounties }: { initialFeaturedSpot: FeaturedSpot | null; bounties: BountyRef[] }) {
   const router = useRouter();
-  const [current, setCurrent] = useState<LiveSpot | null>(
-    spot ? { id: spot.id, name: spot.name, image: spot.image || null, coords: spot.coords } : null,
-  );
-  const [loadingSpot, setLoadingSpot] = useState(false);
-
-  async function another() {
-    setLoadingSpot(true);
-    try {
-      const ex = current?.id ? `?exclude=${encodeURIComponent(current.id)}` : "";
-      const res = await fetch(`/api/spotmap/featured${ex}`, { cache: "no-store" });
-      const data = await res.json();
-      const s = data?.spot;
-      if (s) setCurrent({ id: String(s.id), name: s.name, image: s.thumbnail ?? null, coords: s.lat != null && s.lng != null ? `${s.lat},${s.lng}` : null });
-    } catch {
-      /* keep current */
-    } finally {
-      setLoadingSpot(false);
-    }
-  }
 
   return (
     <Grid id="spots" templateColumns={{ base: "1fr", md: "1fr 1fr" }} gap="24px" mt="48px" fontFamily={MONO}>
-      {/* Discover a Spot */}
-      <Box border={`2px solid ${P.card}`} p="24px">
-        <Flex align="center" justify="space-between" mb="16px">
-          <Text fontWeight={800} fontSize="18px" color={P.accent} textTransform="uppercase">Discover a Spot &#128757;</Text>
-          <Button onClick={() => router.push("/map")} bg="none" border={`2px solid ${P.ghost}`} borderRadius={0} color={P.ui} fontFamily={MONO} fontSize="11px" fontWeight={700} letterSpacing="1px" px="14px" py="8px" h="auto" _hover={{ color: P.body, borderColor: P.faint }}>
-            VIEW MORE
-          </Button>
-        </Flex>
-        <Box position="relative">
-          {current?.image ? (
-            <Image src={current.image} alt="" w="100%" h="220px" objectFit="cover" display="block" opacity={loadingSpot ? 0.5 : 1} transition="opacity 0.2s" />
-          ) : (
-            <Flex w="100%" h="220px" align="center" justify="center" bg={P.card} color={P.faint} fontSize="13px">sem spot</Flex>
-          )}
-          {current?.coords && (
-            <Box position="absolute" left="10px" top="10px" bg="rgba(10,10,10,0.8)" border={`1px solid ${P.accent}`} color={P.accent} fontSize="12px" px="8px" py="4px">
-              &#128205; {current.coords}
-            </Box>
-          )}
-        </Box>
-        <Text fontSize="15px" color={P.body} my="14px" mb="16px">{current?.name ?? "—"}</Text>
-        <Flex gap="12px">
-          <Button flex={1} onClick={another} isDisabled={loadingSpot} bg="none" border={`2px solid ${P.accent}`} borderRadius={0} color={P.accent} fontFamily={MONO} fontWeight={700} letterSpacing="1px" py="12px" h="auto" _hover={{ bg: P.navTint }}>
-            ANOTHER
-          </Button>
-          <Button flex={1} onClick={() => router.push("/map")} bg="none" border={`2px solid ${P.ghost}`} borderRadius={0} color={P.ui} fontFamily={MONO} fontWeight={700} letterSpacing="1px" py="12px" h="auto" _hover={{ color: P.body }}>
-            VIEW ALL SPOTS
-          </Button>
-        </Flex>
+      {/* Discover a Spot — the SAME location-based widget as the homepage. */}
+      <Box>
+        <SpotNearYou initialSpot={initialFeaturedSpot} />
       </Box>
 
       {/* Open Bounties (the rewards total lives in the index rail now) */}


### PR DESCRIPTION
The `/home` "Discover a Spot" section used the **curated** config spot. Swap it for the **same location-based widget the classic homepage uses** — `SpotNearYou`: browser-geolocation featured spot, `ANOTHER` (rolling seen-buffer), `VIEW ALL → /map`.

- SSR the initial spot via `getInitialFeaturedSpot()` (same as `app/page.tsx`) → no skeleton flash.
- The config's curated `spot` is no longer rendered here (the composer picker is left in place, harmless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)