### PR TITLE
feat(home): spot widget matches bounty height + per-line bounty value

### DIFF
--- a/components/home-magazine/SpotAndRewards.tsx
+++ b/components/home-magazine/SpotAndRewards.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Box, Button, Flex, Grid, Text } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
+import { formatEther } from "viem";
 import type { BountyRef } from "@/types/homepage-config";
 import type { FeaturedSpot } from "@/lib/spotmap/featured";
 import SpotNearYou from "@/components/homepage/SpotNearYou";
@@ -10,12 +12,32 @@ import { P, MONO } from "./palette";
 export function SpotAndRewards({ initialFeaturedSpot, bounties }: { initialFeaturedSpot: FeaturedSpot | null; bounties: BountyRef[] }) {
   const router = useRouter();
 
+  // ETH→USD for per-line poidh bounty values (amount is stored as ETH wei).
+  const [ethUsd, setEthUsd] = useState(0);
+  useEffect(() => {
+    let live = true;
+    fetch("/api/prices")
+      .then((r) => r.json())
+      .then((d) => { if (live) setEthUsd(d?.ethereum?.usd ?? 0); })
+      .catch(() => {});
+    return () => { live = false; };
+  }, []);
+
+  const bountyUsd = (b: BountyRef): string | null => {
+    if (b.source !== "poidh" || !b.amount || !ethUsd) return null;
+    try {
+      const usd = parseFloat(formatEther(BigInt(b.amount))) * ethUsd;
+      return usd >= 1 ? `$${Math.round(usd).toLocaleString("en-US")}` : `$${usd.toFixed(2)}`;
+    } catch {
+      return null;
+    }
+  };
+
   return (
-    <Grid id="spots" templateColumns={{ base: "1fr", md: "1fr 1fr" }} gap="24px" mt="48px" fontFamily={MONO}>
-      {/* Discover a Spot — the SAME location-based widget as the homepage. */}
-      <Box>
-        <SpotNearYou initialSpot={initialFeaturedSpot} />
-      </Box>
+    <Grid id="spots" templateColumns={{ base: "1fr", md: "1fr 1fr" }} gap="24px" mt="48px" fontFamily={MONO} alignItems="stretch">
+      {/* Discover a Spot — the SAME location-based widget as the homepage,
+          stretched to match the bounties card height. */}
+      <SpotNearYou initialSpot={initialFeaturedSpot} fill />
 
       {/* Open Bounties (the rewards total lives in the index rail now) */}
       <Flex id="rewards" direction="column" justify="space-between" border={`2px solid ${P.card}`} p="24px">
@@ -26,8 +48,9 @@ export function SpotAndRewards({ initialFeaturedSpot, bounties }: { initialFeatu
             {bounties.map((b, i) => {
               const title = b.source === "poidh" ? b.name || `Bounty ${b.id}` : b.title;
               const sponsor = b.source === "poidh" ? `@${b.issuer?.slice(0, 8) ?? ""}` : b.sponsor;
+              const value = bountyUsd(b);
               return (
-                <Flex key={i} align="center" justify="space-between" py="10px" borderTop={`1px solid ${P.card}`} fontSize="14px">
+                <Flex key={i} align="center" justify="space-between" gap="12px" py="10px" borderTop={`1px solid ${P.card}`} fontSize="14px">
                   <Flex align="center" gap="10px" minW={0}>
                     <Box w="8px" h="8px" bg={P.accent} flexShrink={0} />
                     <Box minW={0}>
@@ -35,6 +58,7 @@ export function SpotAndRewards({ initialFeaturedSpot, bounties }: { initialFeatu
                       {sponsor && <Text fontSize="11px" color={P.faint} isTruncated>{sponsor}</Text>}
                     </Box>
                   </Flex>
+                  {value && <Text fontWeight={800} color={P.accent} whiteSpace="nowrap" flexShrink={0}>{value}</Text>}
                 </Flex>
               );
             })}

--- a/components/homepage/SpotNearYou.tsx
+++ b/components/homepage/SpotNearYou.tsx
@@ -28,6 +28,12 @@ interface SpotNearYouProps {
    * this just removes the skeleton flash for cold visits.
    */
   initialSpot?: FeaturedSpot | null;
+  /**
+   * Stretch to fill the parent's height (the image grows to consume extra
+   * space). Used on /home so the widget matches the adjacent bounties card
+   * height. Off by default (RightSidebar keeps its natural size).
+   */
+  fill?: boolean;
 }
 
 function readSeen(): string[] {
@@ -60,7 +66,7 @@ function formatDistance(km: number): string {
   return `${Math.round(km)} km`;
 }
 
-export default function SpotNearYou({ initialSpot = null }: SpotNearYouProps = {}) {
+export default function SpotNearYou({ initialSpot = null, fill = false }: SpotNearYouProps = {}) {
   const router = useRouter();
   const t = useTranslations("spotWidget");
   const [spot, setSpot] = useState<FeaturedSpot | null>(initialSpot);
@@ -168,7 +174,10 @@ export default function SpotNearYou({ initialSpot = null }: SpotNearYouProps = {
 
   return (
     <Box
-      mt={3}
+      mt={fill ? 0 : 3}
+      h={fill ? "100%" : undefined}
+      display={fill ? "flex" : undefined}
+      flexDirection={fill ? "column" : undefined}
       borderWidth="1px"
       borderColor="whiteAlpha.200"
       borderRadius="0"
@@ -198,14 +207,17 @@ export default function SpotNearYou({ initialSpot = null }: SpotNearYouProps = {
         <Box
           as="a"
           href={spotHref}
-          display="block"
+          display={fill ? "flex" : "block"}
+          flexDirection={fill ? "column" : undefined}
+          flex={fill ? "1" : undefined}
+          minH={0}
           cursor="pointer"
           _hover={{ opacity: 0.92 }}
           transition="opacity 0.15s"
           opacity={isLoading ? 0.6 : 1}
         >
           {spot.thumbnail ? (
-            <Box position="relative" width="100%" height="160px" bg="rgba(255,255,255,0.04)">
+            <Box position="relative" width="100%" height={fill ? "auto" : "160px"} flex={fill ? "1" : undefined} minHeight="160px" bg="rgba(255,255,255,0.04)">
               <Image
                 src={spot.thumbnail}
                 alt={spot.name}

--- a/types/homepage-config.ts
+++ b/types/homepage-config.ts
@@ -35,7 +35,7 @@ export type SpotPick = {
 };
 
 export type BountyRef =
-  | { source: "poidh"; id: string; chainId: number; name: string; issuer: string; image?: string }
+  | { source: "poidh"; id: string; chainId: number; name: string; issuer: string; image?: string; amount?: string }
   | { source: "hive"; author: string; permlink: string; title: string; sponsor: string };
 
 export type FeaturedUser = { username: string };


### PR DESCRIPTION
Two tweaks to the `/home` spot + bounties row:

1. **Equal height** — `SpotNearYou` gets an opt-in `fill` prop (root stretches to 100%, image grows to fill). `/home` passes it so the Discover-a-Spot card matches the adjacent Open Bounties card height (grid `alignItems: stretch`). RightSidebar is unaffected (default off).
2. **Per-line value** — Open Bounties shows a USD value after each line: stored poidh `amount` (ETH wei) × live ETH price (`/api/prices`), right-aligned in accent. Requires the portal's new stored `amount` (mirrored into the sk3 type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Bounty listings now show an estimated USD value for eligible ETH-denominated bounties.
  - USD estimates update using the current ETH-to-USD exchange rate.

- **Style**
  - Improved the “Spot Near You” widget layout so it can expand to fill available space.
  - Adjusted the spots grid for more consistent alignment and sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->