### PR TITLE
fix: profile-not-found flash on first load + SSR crashes on /user/[username]

### DIFF
--- a/components/compose/MarkdownEditor.tsx
+++ b/components/compose/MarkdownEditor.tsx
@@ -1,11 +1,15 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
+import dynamic from "next/dynamic";
 import { Box, Textarea, HStack, IconButton, Button, Flex, Text, useColorModeValue } from "@chakra-ui/react";
 import { useDropzone } from "react-dropzone";
 import { EnhancedMarkdownRenderer } from "../markdown/EnhancedMarkdownRenderer";
 import { FaColumns } from "react-icons/fa";
 import { TbGif } from "react-icons/tb";
 import { MdPermMedia } from "react-icons/md";
-import GIFMakerWithSelector, { GIFMakerRef as GIFMakerWithSelectorRef } from "../homepage/GIFMakerWithSelector";
+import type { GIFMakerRef as GIFMakerWithSelectorRef } from "../homepage/GIFMakerWithSelector";
+// FFmpeg (loaded inside this component) touches browser-only globals at
+// module init, which crashes SSR if bundled into the server render.
+const GIFMakerWithSelector = dynamic(() => import("../homepage/GIFMakerWithSelector"), { ssr: false });
 
 interface MarkdownEditorProps {
   markdown: string;

--- a/components/homepage/GIFMakerWithSelector.tsx
+++ b/components/homepage/GIFMakerWithSelector.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, {
   useRef,
   useImperativeHandle,
@@ -6,8 +8,6 @@ import React, {
   useEffect,
   useCallback,
 } from "react";
-import { FFmpeg } from "@ffmpeg/ffmpeg";
-import { fetchFile } from "@ffmpeg/util";
 import { Box, Input, Button, Text, Select } from "@chakra-ui/react";
 import { useTheme } from "@/app/themeProvider";
 import VideoTimeline from "./VideoTimeline";
@@ -234,11 +234,13 @@ const GIFMakerWithSelector = forwardRef<GIFMakerRef, GIFMakerWithSelectorProps>(
       try {
         if (!ffmpegRef.current) {
           setStatus("Loading FFmpeg...");
+          const { FFmpeg } = await import("@ffmpeg/ffmpeg");
           ffmpegRef.current = new FFmpeg();
           await ffmpegRef.current.load();
         }
         const ffmpeg = ffmpegRef.current;
         setStatus("Converting to GIF...");
+        const { fetchFile } = await import("@ffmpeg/util");
         await ffmpeg.writeFile(videoFile.name, await fetchFile(videoFile));
         const vfCommand = `fps=${fps},scale=320:-1:flags=lanczos`; // Debug log
         

--- a/components/homepage/SnapComposer.tsx
+++ b/components/homepage/SnapComposer.tsx
@@ -88,9 +88,10 @@ import { ImageCompressorRef } from "@/lib/utils/ImageCompressor";
 import imageCompression from "browser-image-compression";
 import { isHeicFile, convertHeicIfNeeded } from "@/lib/utils/heicToJpeg";
 
-import GIFMakerWithSelector, {
-  GIFMakerRef as GIFMakerWithSelectorRef,
-} from "./GIFMakerWithSelector";
+import type { GIFMakerRef as GIFMakerWithSelectorRef } from "./GIFMakerWithSelector";
+// FFmpeg (loaded inside this component) touches browser-only globals at
+// module init, which crashes SSR if bundled into the server render.
+const GIFMakerWithSelector = dynamic(() => import("./GIFMakerWithSelector"), { ssr: false });
 import useHivePower from "@/hooks/useHivePower";
 import { useInstagramHealth } from "@/hooks/useInstagramHealth";
 import { TbGif } from "react-icons/tb";

--- a/components/profile/ProfilePage.tsx
+++ b/components/profile/ProfilePage.tsx
@@ -504,6 +504,15 @@ const ProfilePage = memo(function ProfilePage({ username }: ProfilePageProps) {
   const [activeProfileView, setActiveProfileView] = useState<
     "hive" | "skate" | "zora" | "farcaster" | null
   >(null);
+  // useHiveAccount/useUserbaseProfile default isLoading to false until their
+  // effects fire post-mount, so on the very first render neither hook is
+  // "loading" yet. Without this flag the not-found branch below flashes
+  // before either fetch has actually started. Client-only by design (SSR
+  // and the initial hydration pass both render isMounted=false).
+  const [isMounted, setIsMounted] = useState(false);
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
 
   // Custom hooks
   const { profileData, updateProfileData, refetchBridgeData, adjustFollowerCount } = useProfileData(
@@ -828,7 +837,7 @@ const ProfilePage = memo(function ProfilePage({ username }: ProfilePageProps) {
   const isProfileResolved =
     isHiveProfile || Boolean(userbaseUser) || isEvmAddress;
 
-  if (!isProfileResolved && (isLoading || userbaseLoading)) {
+  if (!isProfileResolved && (!isMounted || isLoading || userbaseLoading)) {
     return (
       <Box
         display="flex"
@@ -841,7 +850,7 @@ const ProfilePage = memo(function ProfilePage({ username }: ProfilePageProps) {
     );
   }
 
-  if (!isProfileResolved && !isLoading && !userbaseLoading) {
+  if (!isProfileResolved && isMounted && !isLoading && !userbaseLoading) {
     return (
       <Box
         display="flex"

--- a/lib/utils/videoThumbnailUtils.ts
+++ b/lib/utils/videoThumbnailUtils.ts
@@ -3,7 +3,6 @@
  */
 
 import React from 'react';
-import { fetchFile } from '@ffmpeg/util';
 import { APP_CONFIG } from "@/config/app.config";
 import { uploadToIpfsSmart } from "./ipfsUpload";
 
@@ -120,6 +119,7 @@ export async function generateThumbnailWithFFmpeg(
     }
     
     const ffmpeg = ffmpegRef.current;
+    const { fetchFile } = await import("@ffmpeg/util");
 
     await ffmpeg.writeFile("input_thumb.mp4", await fetchFile(file));
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -117,7 +117,7 @@ const nextConfig = {
     // out of the bundler entirely so they're required at runtime from
     // node_modules. Also silences the libheif-js "Critical dependency"
     // warning that adds compile time on every build.
-    serverExternalPackages: ['libheif-js', 'heic-convert', 'heic-decode', 'sharp'],
+    serverExternalPackages: ['libheif-js', 'heic-convert', 'heic-decode', 'sharp', 'jsdom', 'isomorphic-dompurify'],
 
     // ESM-only packages that webpack chokes on inside dynamically-imported chunks
     // (e.g. @aioha/providers exposes "./react" with only an "import" condition,


### PR DESCRIPTION
## Summary
- Fixes #187 — the "Profile not found" alert no longer flashes on first visit to a profile page. `useHiveAccount`/`useUserbaseProfile` both default `isLoading` to `false` until their effects fire post-mount, so the not-found branch could render for one frame before either fetch had started. Gated it behind a client-mount flag.
- While verifying that fix in a production build, `/user/[username]` was throwing a 500. Two separate causes, both fixed:
  - `GIFMakerWithSelector` eagerly imported `@ffmpeg/ffmpeg`/`@ffmpeg/util` at module scope and was missing `"use client"`. Since it was statically imported by `SnapComposer`/`MarkdownEditor`, Next executed it during SSR, running ffmpeg's browser-only init code server-side. Now lazy-loaded via `next/dynamic({ ssr: false })` (matching the existing `PublishPreviewDialog` pattern), with the ffmpeg imports themselves also made lazy.
  - `jsdom` (pulled in by `isomorphic-dompurify`, used in the Hive markdown rendering chain) was getting bundled into a webpack server chunk instead of required natively, and `rrweb-cssom`'s `class X extends CSSGroupingRule` pattern breaks across that bundling boundary (`TypeError: n.CSSGroupingRule is not a constructor`). Added `jsdom`/`isomorphic-dompurify` to `serverExternalPackages` alongside the existing `libheif-js`/`heic-convert`/`heic-decode`/`sharp` entries.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `pnpm build` + `next start` in production mode: confirmed both crashes are gone on `/user/[username]`
- [ ] Smoke test on a real deployment (Vercel preview) — local sandbox had unreliable outbound access to live Hive RPC nodes, so full end-to-end 200 on `/user/howweroll` wasn't confirmed locally, only that neither crash reproduces