### PR TITLE
Remove crosspost destination picker from reply composer

### DIFF
--- a/components/homepage/SnapComposer.tsx
+++ b/components/homepage/SnapComposer.tsx
@@ -830,7 +830,8 @@ const SnapComposer = React.memo(function SnapComposer({
     // Hive image/text post (no eligible cross-post) skips straight to publishing.
     const igEligibleNow =
       instagramCrossPost && isMainFeedSnap && canBypassLimit && hasCrossPostMedia;
-    const fcEligibleNow = postToFarcaster && farcasterEligible && !!farcasterLinkage;
+    const fcEligibleNow =
+      postToFarcaster && isMainFeedSnap && farcasterEligible && !!farcasterLinkage;
     const needsPrepareDialog = !!videoUrl || igEligibleNow || fcEligibleNow;
     if (needsPrepareDialog && !publishConfirmedRef.current) {
       setShowPublishPreview(true);
@@ -845,7 +846,9 @@ const SnapComposer = React.memo(function SnapComposer({
     }
 
     const wantsSkatehive = postToHive;
-    const wantsFarcaster = postToFarcaster;
+    // Cross-posting only ever applies to the main-feed composer — a reply
+    // shouldn't fan out to Farcaster regardless of leftover toggle state.
+    const wantsFarcaster = postToFarcaster && isMainFeedSnap;
     // Farcaster-only main-feed snaps still create a masked @skateuser Hive
     // soft-post (overlaid with the user's identity) so there's always a
     // SkateHive post page for the cast / Mini App to open. Replies (non-main-
@@ -2093,7 +2096,7 @@ const SnapComposer = React.memo(function SnapComposer({
                   color="background"
                   _hover={{ bg: "muted", color: "text", border: "tb1" }}
                   isLoading={isLoading}
-                  isDisabled={isLoading || isUploadingMedia || (!postToHive && !postToFarcaster)}
+                  isDisabled={isLoading || isUploadingMedia || (!postToHive && !(postToFarcaster && isMainFeedSnap))}
                   onClick={handleComment}
                   borderRadius={"none"}
                   fontWeight="bold"
@@ -2111,33 +2114,37 @@ const SnapComposer = React.memo(function SnapComposer({
                 >
                   {buttonText}
                 </Button>
-                <DestinationMenu
-                  postToHive={postToHive}
-                  postToFarcaster={postToFarcaster}
-                  postToInstagram={instagramCrossPost}
-                  setPostToHive={setPostToHive}
-                  setPostToFarcaster={setPostToFarcaster}
-                  setPostToInstagram={(v: boolean) => {
-                    // If the user is enabling IG cross-post for the first time
-                    // and we don't have a stored handle, prompt them so the
-                    // caption can @-tag instead of falling back to plain text.
-                    if (v && igHandleStatus === "absent") {
-                      setIgPromptInput("");
-                      setIgPromptOpen(true);
-                      return;
-                    }
-                    setInstagramCrossPost(v);
-                  }}
-                  farcasterChannel={farcasterChannel}
-                  setFarcasterChannel={setFarcasterChannel}
-                  farcasterEligible={farcasterEligible}
-                  farcasterSignerApproved={farcasterSignerApproved}
-                  farcasterUsername={farcasterLinkage?.username || null}
-                  instagramEligible={isMainFeedSnap && canBypassLimit}
-                  instagramHasMedia={hasCrossPostMedia}
-                  isLoading={isLoading}
-                  buttonSize={buttonSize}
-                />
+                {/* Cross-post destination picker — main-feed snaps only. A
+                    reply/comment always goes to Hive alone. */}
+                {isMainFeedSnap && (
+                  <DestinationMenu
+                    postToHive={postToHive}
+                    postToFarcaster={postToFarcaster}
+                    postToInstagram={instagramCrossPost}
+                    setPostToHive={setPostToHive}
+                    setPostToFarcaster={setPostToFarcaster}
+                    setPostToInstagram={(v: boolean) => {
+                      // If the user is enabling IG cross-post for the first time
+                      // and we don't have a stored handle, prompt them so the
+                      // caption can @-tag instead of falling back to plain text.
+                      if (v && igHandleStatus === "absent") {
+                        setIgPromptInput("");
+                        setIgPromptOpen(true);
+                        return;
+                      }
+                      setInstagramCrossPost(v);
+                    }}
+                    farcasterChannel={farcasterChannel}
+                    setFarcasterChannel={setFarcasterChannel}
+                    farcasterEligible={farcasterEligible}
+                    farcasterSignerApproved={farcasterSignerApproved}
+                    farcasterUsername={farcasterLinkage?.username || null}
+                    instagramEligible={isMainFeedSnap && canBypassLimit}
+                    instagramHasMedia={hasCrossPostMedia}
+                    isLoading={isLoading}
+                    buttonSize={buttonSize}
+                  />
+                )}
               </ButtonGroup>
             </Box>
           </HStack>
@@ -2250,7 +2257,7 @@ const SnapComposer = React.memo(function SnapComposer({
             hive: postToHive,
             instagram:
               instagramCrossPost && isMainFeedSnap && canBypassLimit && hasCrossPostMedia,
-            farcaster: postToFarcaster && farcasterEligible && !!farcasterLinkage,
+            farcaster: postToFarcaster && isMainFeedSnap && farcasterEligible && !!farcasterLinkage,
           }}
           maxVideoDuration={15}
           canBypassTrim={canBypassLimit}


### PR DESCRIPTION
## Summary
The reply composer showed the full "Post to" destination picker (SkateHive/Farcaster/Instagram), letting a reply to a skate post fan out to Farcaster. Instagram was already correctly gated behind `isMainFeedSnap`, but Farcaster wasn't — this closes that gap.

## What changed
`components/homepage/SnapComposer.tsx`:
- `fcEligibleNow` and `wantsFarcaster` now also require `isMainFeedSnap`, so a reply never fires a Farcaster cast regardless of leftover toggle state (not just a UI change — the actual cross-post logic is gated)
- `targets.farcaster` passed to `PublishPreviewDialog` got the same gate (found this third ungated spot while implementing)
- The `DestinationMenu` dropdown next to the submit button is only rendered when `isMainFeedSnap` — a reply now shows a plain submit button, no destination picker at all
- Main-feed compose (creating a new top-level snap) is untouched — same dropdown, same toggles, same Farcaster/Instagram cross-post behavior

## Verified
- [x] `tsc --noEmit` clean
- [x] `npm test` passes
- Confirmed every reply/comment call site of `SnapComposer` (inline reply on Snap, SnapReplyModal, NotificationItem, ReplyItem, SnapModal, BountyDetail, SpotPageClient) passes a specific post's permlink as `pp`, so `isMainFeedSnap` is already `false` for all of them — this fix covers every reply context, not just the main feed's inline reply.

## Manual test plan for reviewer
- [ ] Reply to any snap/post → no destination dropdown next to the submit button, just a plain button
- [ ] Reply submits normally to Hive
- [ ] Create a new top-level snap from the home feed → dropdown still there, Farcaster/Instagram toggles still work as before

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted Farcaster cross-posting options to main-feed posts.
  * Prevented replies from triggering Farcaster preparation or publishing behavior.
  * Updated submit-button availability to reflect eligible destinations.
  * Hid Farcaster destination controls and previews when composing replies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->