### PR TITLE
Fix video iframe covering the snap modal's right panel

### DIFF
--- a/app/user/[username]/snap/[permlink]/page.tsx
+++ b/app/user/[username]/snap/[permlink]/page.tsx
@@ -35,7 +35,7 @@ async function fetchPostData(username: string, permlink: string): Promise<Discus
 function cleanBodyForDescription(body: string): string {
     return body
         .replace(/!\[.*?\]\(.*?\)/g, '')       // Remove image markdown
-        .replace(/<iframe[^>]*>.*?<\/iframe>/gi, '') // Remove iframes
+        .replace(/<iframe[^>]*>[\s\S]*?<\/iframe>/gi, '') // Remove iframes (multi-line embed markup)
         .replace(/<[^>]*>/g, '')               // Remove HTML tags
         .replace(/^#{1,6}\s+/gm, '')           // Remove headers
         .replace(/\*{1,2}([^*]+)\*{1,2}/g, '$1') // Remove bold/italic

--- a/components/profile/SnapModal.tsx
+++ b/components/profile/SnapModal.tsx
@@ -163,7 +163,10 @@ const SnapModal = ({
   const cleanBodyText = (body: string) => {
     if (!body) return "";
     let cleaned = body.replace(/!\[.*?\]\(.*?\)/g, "");
-    cleaned = cleaned.replace(/<iframe[^>]*>.*?<\/iframe>/gi, "");
+    // [\s\S]*? (not .*?) so this also matches multi-line iframes — the video
+    // embed markdown (generateVideoIframeMarkdown) spans several lines, and a
+    // plain "." never matches "\n" without the "s" flag.
+    cleaned = cleaned.replace(/<iframe[^>]*>[\s\S]*?<\/iframe>/gi, "");
     cleaned = cleaned.replace(/\n\s*\n/g, "\n").trim();
     return cleaned;
   };


### PR DESCRIPTION
## Summary
When a post has a video (trimmed or not), opening it in `SnapModal` showed the video's raw `<iframe>` markup filling the entire right panel, hiding the vote/comment/reply actions underneath.

## Root cause
Video posts embed the video as a **multi-line** `<iframe>` block (`generateVideoIframeMarkdown` in `lib/markdown/composeUtils.ts`):
```html
<iframe src="..." 
    title="..."
    width="100%" 
    height="400"
    ...
    allowfullscreen>
</iframe>
```
`SnapModal.tsx`'s `cleanBodyText` tries to strip this before rendering the post text in the right panel, using:
```js
cleaned.replace(/<iframe[^>]*>.*?<\/iframe>/gi, "")
```
`.` doesn't match `\n` in JS regex without the `s` flag, so the regex silently fails on this multi-line markup — the raw iframe (fixed `height="400"`) stays in the text and gets rendered for real by `HiveMarkdown`, covering the panel.

This exact bug class was already fixed elsewhere in the codebase (`lib/markdown/MarkdownRenderer.ts`, with a comment: *"Use `[\s\S]*?` instead of `.*?` to match multi-line iframes"*) — `SnapModal.tsx` just never got the same treatment.

## What changed
- `components/profile/SnapModal.tsx`: `cleanBodyText`'s iframe regex now uses `[\s\S]*?` instead of `.*?`
- `app/user/[username]/snap/[permlink]/page.tsx`: found the identical broken regex in the SEO description generator (`cleanBodyForDescription`) — fixed for consistency. Currently masked there by a follow-up strip-all-HTML-tags pass, so no visible bug, but same dead regex.

## Verified
- [x] `tsc --noEmit` clean
- [x] `npm test` passes
- [x] Sanity-checked the regex directly against a realistic multi-line iframe string: old regex fails to match (bug reproduced), new regex strips it fully

## Manual test plan for reviewer
- [ ] Publish a snap with a trimmed video → open it in the snap modal (from profile or feed) → right panel shows avatar/author/body text, vote button, comments, and reply composer — no video/iframe bleeding into the right panel
- [ ] Publish a snap with a non-trimmed video → same check (bug wasn't trim-specific, any video-bearing post embeds the same multi-line iframe)
- [ ] A snap with only images (no video) still displays normally in the modal — no regression
- [ ] A snap with only text still displays normally in the modal — no regression
- [ ] Left panel still shows the video and plays/loops correctly (untouched code path)

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snap descriptions and modal content cleanup by removing embedded iframe markup, including iframes that span multiple lines.
  * Prevented iframe code from appearing in rendered snap text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->