### PR TITLE
Progressive comment loading + remove blocking spinner (fixes #204)

### DIFF
--- a/components/homepage/Conversation.tsx
+++ b/components/homepage/Conversation.tsx
@@ -11,8 +11,6 @@ import {
   HStack,
   Button,
   VStack,
-  Spinner,
-  useToken,
   useTheme,
   Avatar,
   Input,
@@ -94,7 +92,6 @@ const Conversation = ({
   const theme = useTheme();
   const toast = useToast();
   const showError = useErrorToast();
-  const [primaryColor] = useToken("colors", ["primary"]);
 
   // Theme-aware colors
   const mobileBgColor = useColorModeValue("black", "black");
@@ -496,25 +493,6 @@ const Conversation = ({
   const onBackClick = useCallback(() => {
     setConversation(undefined);
   }, [setConversation]);
-
-  // Early return AFTER all hooks have been called
-  if (isLoading) {
-    return (
-      <Box
-        h="100vh"
-        bg={mobileBgColor}
-        display="flex"
-        alignItems="center"
-        justifyContent="center"
-        borderTopRadius="20px"
-      >
-        <VStack spacing={4}>
-          <Spinner size="xl" color={primaryColor} />
-          <Text color={mobileTextColor}>Loading conversation...</Text>
-        </VStack>
-      </Box>
-    );
-  }
 
   // Error state for comments
   if (!comments && !isLoading) {

--- a/hooks/useComments.ts
+++ b/hooks/useComments.ts
@@ -57,10 +57,31 @@ export function useComments(
 
     const fetchAndUpdateComments = useCallback(async () => {
         setIsLoading(true);
+        setError(null);
         try {
-            const fetchedComments = await fetchComments(author, permlink, recursive);
-            setComments(fetchedComments);
+            // Fetch the top level first and render it immediately — when
+            // recursive, nested replies are filled in per top-level comment
+            // below without blocking this initial render.
+            const topLevel = await fetchComments(author, permlink, false);
+            setComments(topLevel);
             setIsLoading(false);
+
+            if (recursive) {
+                await Promise.all(
+                    topLevel.map(async (comment) => {
+                        if (!comment.children || comment.children <= 0) return;
+                        const replies = await fetchComments(comment.author, comment.permlink, true);
+                        const filteredReplies = filterAutoComments(replies);
+                        setComments((prev) =>
+                            prev.map((c) =>
+                                c.author === comment.author && c.permlink === comment.permlink
+                                    ? { ...c, replies: filteredReplies as any }
+                                    : c
+                            )
+                        );
+                    })
+                );
+            }
         } catch (err: any) {
             setError(err.message ? err.message : "Error loading comments");
             console.error(err);


### PR DESCRIPTION
## Summary
Opening a post thread (`Conversation` view) showed a full-page spinner that blocked all rendering until the entire recursive comment tree finished loading — on threads with many nested replies, this meant several sequential Hive RPC calls before anything appeared.

## Root cause
- `useComments.ts` fetched the whole recursive tree (`Promise.all` per level, each level gated on the previous one finishing) and called `setComments` exactly once, at the very end.
- `Conversation.tsx` had an early `if (isLoading) return <full-page spinner>` **before** its own component body — which meant the existing comment-list skeleton (`COMMENT_SKELETON_COUNT`, further down in the render) was permanently unreachable dead code.

## What changed

**`hooks/useComments.ts`**
- `fetchAndUpdateComments` now fetches the top-level comments first (one RPC call) and calls `setComments` immediately — the UI can render as soon as top-level comments arrive.
- When `recursive` is true, each top-level comment's own subtree is then fetched in parallel (not sequentially, not blocking siblings) and merged into `comments` state as each one resolves. A comment with a short thread appears fully loaded quickly; a sibling with a deep thread keeps filling in the background without blocking anything else.
- Non-recursive callers (`SnapModal`, `BountyDetail`, etc. — anything passing `recursive=false`) are completely unaffected: same single-call behavior as before.

**`components/homepage/Conversation.tsx`**
- Removed the full-page blocking spinner early return.
- The already-written skeleton in the comments list body (gated on `isLoading`, now top-level-only and much shorter-lived) is reachable and does the job instead.
- Removed `Spinner`/`useToken`/`primaryColor`, which existed only for the removed block.

## Verified
- [x] `tsc --noEmit` clean
- [x] `npm test` passes
- [x] `next build` succeeds
- [x] Dev server smoke test: fetched a real post page (`/post/gnars/gnar-connect-rio-20260713`), 200, no server errors in the log

## What still needs a human (visual/timing confirmation, not observable via curl)
- [ ] Open a post with a busy comment thread → top-level comments + skeleton for the rest should appear quickly, instead of one long blank/spinner wait
- [ ] Comments with deep nested replies should visibly fill in progressively rather than everything popping in at once at the end
- [ ] A post with zero comments still shows the "No comments yet" empty state correctly (not stuck on skeleton)
- [ ] `SnapModal` (profile grid) and any other `useComments(..., false)` caller — unchanged behavior, no regression

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comments now appear sooner, with top-level comments displayed while replies continue loading.
  * Replies are loaded and attached progressively for a smoother conversation experience.

* **Bug Fixes**
  * Improved loading-state rendering on smaller screens with skeleton placeholders.
  * Previous comment errors are cleared before retrying a load.
  * Theme-aware styling now applies more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->