### PR TITLE
feat(wallet): Hive-Engine (L2) + Magi cross-chain swaps

### DIFF
--- a/components/wallet/CrossChainSwapPanel.tsx
+++ b/components/wallet/CrossChainSwapPanel.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Box, Button, HStack, Input, Spinner, Text, VStack, useToast } from "@chakra-ui/react";
+import { FaBitcoin, FaLayerGroup } from "react-icons/fa";
+import { useAioha } from "@aioha/react-ui";
+import { KeyTypes } from "@aioha/aioha";
+import useHiveAccount from "@/hooks/useHiveAccount";
+import { extractNumber } from "@/lib/utils/extractNumber";
+import {
+  buildHeSwapOp,
+  getHeBalances,
+  getHiveEngineQuote,
+  HE_ASSETS,
+  type HeQuote,
+} from "@/lib/hive/hiveEngine";
+import {
+  executeMagiSwap,
+  getMagiClient,
+  getMagiPreview,
+  isValidBtcAddress,
+  type MagiAssetIn,
+  type MagiPreview,
+} from "@/lib/hive/magi";
+
+type SubMode = "l2" | "btc";
+const L2_SYMBOLS = HE_ASSETS.map((a) => a.symbol); // SWAP.HIVE / SWAP.HBD / SWAP.BTC
+
+/**
+ * Hive-Engine (L2 diesel-pool) swaps + Magi cross-chain HIVE/HBD → BTC, signed
+ * with Aioha. Both are Hive ops (custom_json / transfer) so Keychain, KeepKey,
+ * and other Aioha providers all work.
+ */
+export default function CrossChainSwapPanel() {
+  const { user, aioha } = useAioha();
+  const { hiveAccount } = useHiveAccount(user || "");
+  const toast = useToast();
+
+  const [subMode, setSubMode] = useState<SubMode>("l2");
+
+  // Balances -----------------------------------------------------------------
+  const hiveBalance = hiveAccount?.balance ? extractNumber(hiveAccount.balance.toString()) : 0;
+  const hbdBalance = hiveAccount?.hbd_balance ? extractNumber(hiveAccount.hbd_balance.toString()) : 0;
+  const [heBalances, setHeBalances] = useState<Record<string, number>>({});
+  useEffect(() => {
+    if (!user) return;
+    let cancelled = false;
+    getHeBalances(user)
+      .then((rows) => {
+        if (cancelled) return;
+        const map: Record<string, number> = {};
+        for (const r of rows) map[r.symbol] = Number(r.balance) || 0;
+        setHeBalances(map);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  const magiClient = useMemo(() => (aioha ? getMagiClient(aioha) : null), [aioha]);
+
+  const notify = (title: string, status: "error" | "success" | "info" = "error") =>
+    toast({ title, status, duration: 4000, isClosable: true });
+
+  // ---- Hive-Engine (L2) ----------------------------------------------------
+  const [l2Sell, setL2Sell] = useState("SWAP.HBD");
+  const [l2Buy, setL2Buy] = useState("SWAP.BTC");
+  const [l2Amount, setL2Amount] = useState("");
+  const [l2Quote, setL2Quote] = useState<HeQuote | null>(null);
+  const [l2Quoting, setL2Quoting] = useState(false);
+  const [l2Busy, setL2Busy] = useState(false);
+  const [l2Err, setL2Err] = useState<string | null>(null);
+
+  useEffect(() => {
+    setL2Quote(null);
+    setL2Err(null);
+    const amt = Number(l2Amount);
+    if (!(amt > 0) || l2Sell === l2Buy) return;
+    const id = setTimeout(async () => {
+      setL2Quoting(true);
+      try {
+        const q = await getHiveEngineQuote({ sellSymbol: l2Sell, buySymbol: l2Buy, amountIn: l2Amount, slippagePct: 0.5 });
+        setL2Quote(q);
+      } catch (e) {
+        setL2Err(e instanceof Error ? e.message : "No route");
+      } finally {
+        setL2Quoting(false);
+      }
+    }, 500);
+    return () => clearTimeout(id);
+  }, [l2Amount, l2Sell, l2Buy]);
+
+  const doL2Swap = async () => {
+    if (!user || !aioha || !l2Quote) return;
+    if (Number(l2Amount) > (heBalances[l2Sell] ?? 0)) return notify(`Insufficient ${l2Sell}`);
+    setL2Busy(true);
+    try {
+      const ops = l2Quote.execPlan.map((h) => buildHeSwapOp(user, h));
+      const res = await aioha.signAndBroadcastTx(ops, KeyTypes.Active);
+      if ((res as { success?: boolean })?.success === false) throw new Error((res as { error?: string })?.error || "Rejected");
+      notify(`Swapped ${l2Amount} ${l2Sell} → ${l2Buy}`, "success");
+      setL2Amount("");
+      setL2Quote(null);
+    } catch (e) {
+      notify(e instanceof Error ? e.message : "Swap failed");
+    } finally {
+      setL2Busy(false);
+    }
+  };
+
+  // ---- Magi cross-chain (→ BTC) --------------------------------------------
+  const [mIn, setMIn] = useState<MagiAssetIn>("HBD");
+  const [mAmount, setMAmount] = useState("");
+  const [mAddr, setMAddr] = useState("");
+  const [mPreview, setMPreview] = useState<MagiPreview | null>(null);
+  const [mQuoting, setMQuoting] = useState(false);
+  const [mBusy, setMBusy] = useState(false);
+  const [mErr, setMErr] = useState<string | null>(null);
+
+  const mAddrOk = isValidBtcAddress(mAddr);
+
+  const quoteMagi = useCallback(async () => {
+    setMPreview(null);
+    setMErr(null);
+    if (!magiClient || !user || !(Number(mAmount) > 0) || !mAddrOk) return;
+    setMQuoting(true);
+    try {
+      const p = await getMagiPreview(magiClient, { username: user, assetIn: mIn, assetOut: "BTC", amountIn: mAmount, recipient: mAddr, slippagePct: 0.5 });
+      setMPreview(p);
+    } catch (e) {
+      setMErr(e instanceof Error ? e.message : "No quote");
+    } finally {
+      setMQuoting(false);
+    }
+  }, [magiClient, user, mAmount, mAddr, mAddrOk, mIn]);
+
+  useEffect(() => {
+    const id = setTimeout(quoteMagi, 600);
+    return () => clearTimeout(id);
+  }, [quoteMagi]);
+
+  const doMagiSwap = async () => {
+    if (!magiClient || !user || !mPreview) return;
+    const bal = mIn === "HIVE" ? hiveBalance : hbdBalance;
+    if (Number(mAmount) > bal) return notify(`Insufficient ${mIn}`);
+    if (!mAddrOk) return notify("Enter a valid Bitcoin address");
+    setMBusy(true);
+    try {
+      const txId = await executeMagiSwap(magiClient, { username: user, assetIn: mIn, assetOut: "BTC", amountIn: mAmount, recipient: mAddr, slippagePct: 0.5 });
+      notify(`Magi swap submitted (tx ${txId.slice(0, 8)}…) — BTC settles shortly`, "success");
+      setMAmount("");
+      setMPreview(null);
+    } catch (e) {
+      notify(e instanceof Error ? e.message : "Magi swap failed");
+    } finally {
+      setMBusy(false);
+    }
+  };
+
+  // ---- shared UI helpers ----------------------------------------------------
+  const fieldSx = { bg: "background", color: "primary", borderColor: "primary", fontFamily: "mono" } as const;
+  const eyebrow = { fontSize: "10px", fontFamily: "mono", color: "primary", opacity: 0.7, letterSpacing: "wider", textTransform: "uppercase" } as const;
+
+  if (!user) {
+    return (
+      <Text fontFamily="mono" fontSize="sm" color="primary" opacity={0.7} py={4} textAlign="center">
+        Connect your Hive account to swap on Hive-Engine or bridge to BTC via Magi.
+      </Text>
+    );
+  }
+
+  return (
+    <VStack align="stretch" spacing={3}>
+      {/* sub-mode toggle */}
+      <HStack spacing={0} border="1px solid" borderColor="primary">
+        {([["l2", "Hive-Engine", <FaLayerGroup key="l" />], ["btc", "→ Bitcoin", <FaBitcoin key="b" />]] as const).map(([key, label, icon]) => (
+          <Button
+            key={key}
+            flex={1}
+            size="sm"
+            borderRadius="none"
+            fontFamily="mono"
+            fontSize="xs"
+            textTransform="uppercase"
+            leftIcon={icon}
+            bg={subMode === key ? "primary" : "transparent"}
+            color={subMode === key ? "background" : "primary"}
+            opacity={subMode === key ? 1 : 0.6}
+            _hover={{ opacity: 1 }}
+            onClick={() => setSubMode(key as SubMode)}
+          >
+            {label}
+          </Button>
+        ))}
+      </HStack>
+
+      {subMode === "l2" ? (
+        <VStack align="stretch" spacing={2}>
+          <Text {...eyebrow}>Swap Hive-Engine tokens (diesel pools)</Text>
+          <HStack>
+            <VStack flex={1} align="stretch" spacing={1}>
+              <Text {...eyebrow}>From · bal {(heBalances[l2Sell] ?? 0).toFixed(6)}</Text>
+              <select value={l2Sell} onChange={(e) => setL2Sell(e.target.value)} style={{ background: "var(--chakra-colors-background)", color: "var(--chakra-colors-primary)", fontFamily: "monospace", padding: 6, border: "1px solid var(--chakra-colors-primary)" }}>
+                {L2_SYMBOLS.map((s) => (<option key={s} value={s}>{s}</option>))}
+              </select>
+            </VStack>
+            <VStack flex={1} align="stretch" spacing={1}>
+              <Text {...eyebrow}>To</Text>
+              <select value={l2Buy} onChange={(e) => setL2Buy(e.target.value)} style={{ background: "var(--chakra-colors-background)", color: "var(--chakra-colors-primary)", fontFamily: "monospace", padding: 6, border: "1px solid var(--chakra-colors-primary)" }}>
+                {L2_SYMBOLS.filter((s) => s !== l2Sell).map((s) => (<option key={s} value={s}>{s}</option>))}
+              </select>
+            </VStack>
+          </HStack>
+          <Input placeholder="0.0" value={l2Amount} onChange={(e) => setL2Amount(e.target.value)} type="number" sx={fieldSx} />
+          <HStack justify="space-between" minH="18px">
+            <Text fontSize="xs" fontFamily="mono" color="primary" opacity={0.7}>
+              {l2Quoting ? "quoting…" : l2Quote ? `≈ ${l2Quote.expectedOut.toFixed(8)} ${l2Buy}${l2Quote.hops > 1 ? ` · ${l2Quote.hops}-hop` : ""}` : l2Err || ""}
+            </Text>
+            {l2Quote && <Text fontSize="xs" fontFamily="mono" color="primary" opacity={0.6}>min {l2Quote.minOut.toFixed(8)}</Text>}
+          </HStack>
+          {l2Buy === "SWAP.BTC" && (
+            <Text fontSize="10px" fontFamily="mono" color="primary" opacity={0.6}>SWAP.BTC pools are thin — rate can be poor. To reach real BTC, withdraw SWAP.BTC via the Hive-Engine gateway.</Text>
+          )}
+          <Button bg="primary" color="background" fontFamily="mono" borderRadius="none" isDisabled={!l2Quote || l2Busy} isLoading={l2Busy} onClick={doL2Swap}>
+            Swap
+          </Button>
+        </VStack>
+      ) : (
+        <VStack align="stretch" spacing={2}>
+          <Text {...eyebrow}>Bridge to real BTC via Magi (routes through HBD)</Text>
+          <HStack>
+            {(["HBD", "HIVE"] as const).map((a) => (
+              <Button key={a} flex={1} size="sm" borderRadius="none" fontFamily="mono" bg={mIn === a ? "primary" : "transparent"} color={mIn === a ? "background" : "primary"} borderWidth="1px" borderColor="primary" onClick={() => setMIn(a)}>
+                {a} → BTC
+              </Button>
+            ))}
+          </HStack>
+          <Text {...eyebrow}>Amount · bal {(mIn === "HIVE" ? hiveBalance : hbdBalance).toFixed(3)}</Text>
+          <Input placeholder="0.0" value={mAmount} onChange={(e) => setMAmount(e.target.value)} type="number" sx={fieldSx} />
+          <Text {...eyebrow}>Your Bitcoin address</Text>
+          <Input placeholder="bc1… / 1… / 3…" value={mAddr} onChange={(e) => setMAddr(e.target.value)} sx={{ ...fieldSx, borderColor: mAddr && !mAddrOk ? "red.400" : "primary" }} />
+          {mAddr && !mAddrOk && <Text fontSize="10px" color="red.400" fontFamily="mono">Not a valid Bitcoin address (not an xpub/zpub).</Text>}
+          <HStack justify="space-between" minH="18px">
+            <Text fontSize="xs" fontFamily="mono" color="primary" opacity={0.7}>
+              {mQuoting ? "quoting…" : mPreview ? `≈ ${mPreview.expectedOut} BTC` : mErr || ""}
+            </Text>
+            {mPreview && <Text fontSize="xs" fontFamily="mono" color="primary" opacity={0.6}>min {mPreview.minOut}</Text>}
+          </HStack>
+          <Text fontSize="10px" fontFamily="mono" color="primary" opacity={0.6}>Mainnet · signs two Hive ops. Magi settles BTC to your address after its confirmations. (SDK v0.0.3 — start small.)</Text>
+          <Button bg="primary" color="background" fontFamily="mono" borderRadius="none" isDisabled={!mPreview || mBusy || !mAddrOk} isLoading={mBusy} onClick={doMagiSwap}>
+            {mBusy ? <Spinner size="sm" /> : "Swap to BTC"}
+          </Button>
+        </VStack>
+      )}
+    </VStack>
+  );
+}

--- a/components/wallet/UnifiedSwapSection.tsx
+++ b/components/wallet/UnifiedSwapSection.tsx
@@ -13,7 +13,8 @@ import {
   IconButton,
   useToast,
 } from "@chakra-ui/react";
-import { FaExchangeAlt, FaHive, FaInfoCircle, FaCog } from "react-icons/fa";
+import { FaExchangeAlt, FaHive, FaInfoCircle, FaCog, FaBitcoin } from "react-icons/fa";
+import CrossChainSwapPanel from "./CrossChainSwapPanel";
 import { useAioha } from "@aioha/react-ui";
 import { shimmerStyles } from "@/lib/utils/animations";
 import { KeyTypes } from "@aioha/aioha";
@@ -332,7 +333,7 @@ function HiveSwapPanel({
 }
 
 // ─── Unified wrapper ──────────────────────────────────────────────────────────
-type SwapMode = "hive" | "erc20" | "admin";
+type SwapMode = "hive" | "crosschain" | "erc20" | "admin";
 
 export default function UnifiedSwapSection(props: UnifiedSwapSectionProps) {
   const t = useTranslations();
@@ -365,6 +366,8 @@ export default function UnifiedSwapSection(props: UnifiedSwapSectionProps) {
       : hasHive
         ? ["hive"]
         : ["erc20"];
+    // Hive-Engine (L2) + Magi cross-chain (→ BTC) — available to any Hive user.
+    if (hasHive) core.splice(1, 0, "crosschain");
     if (isSplitAdmin) core.push("admin");
     return core;
   }, [showBothCore, hasHive, isSplitAdmin]);
@@ -382,6 +385,7 @@ export default function UnifiedSwapSection(props: UnifiedSwapSectionProps) {
 
   const tabMeta: Record<SwapMode, { label: string; icon: React.ReactElement }> = {
     hive: { label: t("swapAdmin.hiveTab"), icon: <FaHive /> },
+    crosschain: { label: "BTC / L2", icon: <FaBitcoin /> },
     erc20: { label: t("swapAdmin.erc20Tab"), icon: <FaExchangeAlt /> },
     admin: { label: t("swapAdmin.tab"), icon: <FaCog /> },
   };
@@ -451,6 +455,8 @@ export default function UnifiedSwapSection(props: UnifiedSwapSectionProps) {
             hbdPrice={hbdPrice}
             isPriceLoading={isPriceLoading}
           />
+        ) : mode === "crosschain" ? (
+          <CrossChainSwapPanel />
         ) : mode === "admin" ? (
           <SwapFeeAdminPanel />
         ) : (

--- a/lib/hive/hiveEngine.ts
+++ b/lib/hive/hiveEngine.ts
@@ -1,0 +1,203 @@
+/**
+ * Hive-Engine (layer-2) diesel-pool swaps for SWAP.* tokens (SWAP.HIVE /
+ * SWAP.HBD / SWAP.BTC / …). A swap is a single `custom_json` op per hop, signed
+ * with Aioha (`aioha.signAndBroadcastTx(ops, KeyTypes.Active)`).
+ *
+ * Many pairs have no direct pool, so routes go through the SWAP.HIVE hub
+ * (e.g. SWAP.HBD → SWAP.HIVE → SWAP.BTC). Ported from swapspro; adapted to
+ * Aioha signing and self-contained types.
+ *
+ * ⚠️ SWAP.BTC liquidity is thin/poorly-arbitraged — quotes reflect the real rate.
+ */
+
+const HE_RPC = "https://api.hive-engine.com/rpc/contracts";
+export const HE_SIDECHAIN_ID = "ssc-mainnet-hive";
+const TRADE_FEE_MUL = 0.9975; // marketpools params (0.25% fee)
+const HUB = "SWAP.HIVE";
+const HE_TIMEOUT_MS = 12_000;
+
+/** A Hive operation tuple, as Aioha's signAndBroadcastTx expects. */
+export type HiveOp = [string, Record<string, unknown>];
+
+async function heFind<T>(contract: string, table: string, query: object, limit = 1000): Promise<T[]> {
+  const res = await fetch(HE_RPC, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", method: "find", params: { contract, table, query, limit, offset: 0 }, id: 1 }),
+    signal: AbortSignal.timeout(HE_TIMEOUT_MS),
+  });
+  const body = await res.json();
+  if (body.error) throw new Error(body.error.message || "Hive-Engine RPC error");
+  return (body.result ?? []) as T[];
+}
+
+export interface HePool {
+  tokenPair: string; // "TOKEN1:TOKEN2" (base:quote)
+  baseQuantity: string;
+  quoteQuantity: string;
+  precision: number;
+}
+export interface HeBalanceRow {
+  account: string;
+  symbol: string;
+  balance: string;
+}
+
+export interface HeAsset {
+  symbol: string;
+  name: string;
+  cgId: string; // CoinGecko id for USD pricing
+  precision: number;
+}
+export const HE_ASSETS: HeAsset[] = [
+  { symbol: "SWAP.HIVE", name: "Wrapped HIVE", cgId: "hive", precision: 8 },
+  { symbol: "SWAP.HBD", name: "Wrapped HBD", cgId: "hive_dollar", precision: 8 },
+  { symbol: "SWAP.BTC", name: "Wrapped BTC", cgId: "bitcoin", precision: 8 },
+];
+export const HE_ASSET_BY_SYMBOL: Record<string, HeAsset> = Object.fromEntries(HE_ASSETS.map((a) => [a.symbol, a]));
+
+export const getHeBalances = (account: string) => heFind<HeBalanceRow>("tokens", "balances", { account });
+
+// ---- Routing + constant-product math (pure) ---------------------------------
+
+export interface SwapHop {
+  tokenPair: string;
+  tokenSymbol: string;
+  buySymbol: string;
+}
+
+export function findRoute(sell: string, buy: string, pools: Set<string>): SwapHop[] | null {
+  if (sell === buy) return null;
+  const ab = `${sell}:${buy}`;
+  const ba = `${buy}:${sell}`;
+  if (pools.has(ab)) return [{ tokenPair: ab, tokenSymbol: sell, buySymbol: buy }];
+  if (pools.has(ba)) return [{ tokenPair: ba, tokenSymbol: sell, buySymbol: buy }];
+  if (sell !== HUB && buy !== HUB) {
+    const a = findRoute(sell, HUB, pools);
+    const b = findRoute(HUB, buy, pools);
+    if (a && b) return [...a, ...b];
+  }
+  return null;
+}
+
+export function poolAmountOut(amountIn: number, liqIn: number, liqOut: number): number {
+  if (!(amountIn > 0) || !(liqIn > 0) || !(liqOut > 0)) return 0;
+  const effIn = amountIn * TRADE_FEE_MUL;
+  return (effIn * liqOut) / (liqIn + effIn);
+}
+
+function orientedReserves(pool: HePool, sellSymbol: string): { liqIn: number; liqOut: number } {
+  const [base] = pool.tokenPair.split(":");
+  const b = Number(pool.baseQuantity);
+  const q = Number(pool.quoteQuantity);
+  return sellSymbol === base ? { liqIn: b, liqOut: q } : { liqIn: q, liqOut: b };
+}
+
+export function formatHeAmount(amount: number, precision = 8): string {
+  return amount.toFixed(precision);
+}
+
+export interface ExecHop {
+  tokenPair: string;
+  tokenSymbol: string;
+  tokenAmount: string;
+  minAmountOut: string;
+}
+
+/** Conservative plan: each hop consumes the previous hop's guaranteed-min output,
+ *  so all ops broadcast in one transaction without a later hop reverting. */
+export function buildExecPlan(route: SwapHop[], amountIn: number, slippagePct: number, byPair: Record<string, HePool>): ExecHop[] {
+  const plan: ExecHop[] = [];
+  let inAmt = amountIn;
+  for (const hop of route) {
+    const pool = byPair[hop.tokenPair];
+    if (!pool) throw new Error(`Missing pool ${hop.tokenPair}`);
+    const { liqIn, liqOut } = orientedReserves(pool, hop.tokenSymbol);
+    const out = poolAmountOut(inAmt, liqIn, liqOut);
+    if (!(out > 0)) throw new Error("Insufficient pool liquidity for this size");
+    plan.push({ tokenPair: hop.tokenPair, tokenSymbol: hop.tokenSymbol, tokenAmount: formatHeAmount(inAmt), minAmountOut: formatHeAmount(out * (1 - slippagePct / 100)) });
+    inAmt = out * (1 - slippagePct / 100);
+  }
+  return plan;
+}
+
+/** The `custom_json` op for one pool swap (exactInput with slippage floor). */
+export function buildHeSwapOp(username: string, hop: ExecHop): HiveOp {
+  return [
+    "custom_json",
+    {
+      required_auths: [username],
+      required_posting_auths: [],
+      id: HE_SIDECHAIN_ID,
+      json: JSON.stringify({
+        contractName: "marketpools",
+        contractAction: "swapTokens",
+        contractPayload: {
+          tokenPair: hop.tokenPair,
+          tokenSymbol: hop.tokenSymbol,
+          tokenAmount: hop.tokenAmount,
+          tradeType: "exactInput",
+          minAmountOut: hop.minAmountOut,
+        },
+      }),
+    },
+  ];
+}
+
+// ---- Live pools + quote -----------------------------------------------------
+
+let poolCache: { at: number; set: Set<string>; byPair: Record<string, HePool> } | null = null;
+const POOL_TTL_MS = 60_000;
+
+async function getPoolGraph(): Promise<{ set: Set<string>; byPair: Record<string, HePool> }> {
+  if (poolCache && Date.now() - poolCache.at < POOL_TTL_MS) return poolCache;
+  const pools = await heFind<HePool>("marketpools", "pools", {}, 1000);
+  const set = new Set<string>();
+  const byPair: Record<string, HePool> = {};
+  for (const p of pools) {
+    set.add(p.tokenPair);
+    byPair[p.tokenPair] = p;
+  }
+  poolCache = { at: Date.now(), set, byPair };
+  return poolCache;
+}
+
+export interface HeQuote {
+  route: SwapHop[];
+  execPlan: ExecHop[];
+  expectedOut: number;
+  minOut: number;
+  hops: number;
+}
+
+/** Quote a Hive-Engine swap (auto multi-hop via SWAP.HIVE). Throws if unroutable. */
+export async function getHiveEngineQuote(params: {
+  sellSymbol: string;
+  buySymbol: string;
+  amountIn: string;
+  slippagePct?: number;
+}): Promise<HeQuote> {
+  const amountIn = Number(params.amountIn) || 0;
+  if (!(amountIn > 0)) throw new Error("Enter an amount");
+  const { set, byPair } = await getPoolGraph();
+  const route = findRoute(params.sellSymbol, params.buySymbol, set);
+  if (!route) throw new Error(`No Hive-Engine route for ${params.sellSymbol} → ${params.buySymbol}`);
+  const slippage = params.slippagePct ?? 0.5;
+
+  // Expected (optimistic) chain for display.
+  let expected = amountIn;
+  for (const hop of route) {
+    const { liqIn, liqOut } = orientedReserves(byPair[hop.tokenPair], hop.tokenSymbol);
+    expected = poolAmountOut(expected, liqIn, liqOut);
+  }
+  if (!(expected > 0)) throw new Error("Insufficient pool liquidity for this size");
+
+  const execPlan = buildExecPlan(route, amountIn, slippage, byPair);
+  return {
+    route,
+    execPlan,
+    expectedOut: expected,
+    minOut: Number(execPlan[execPlan.length - 1].minAmountOut),
+    hops: route.length,
+  };
+}

--- a/lib/hive/magi.ts
+++ b/lib/hive/magi.ts
@@ -1,0 +1,82 @@
+/**
+ * Magi (VSC) cross-chain swaps for skatehive — HIVE/HBD → real BTC, routed
+ * through HBD. Ported from swapspro; here we pass the app's Aioha instance to
+ * `createMagi`, so `client.quickSwap` signs + broadcasts via Aioha directly
+ * (the ops are Hive transfer/custom_json).
+ *
+ * ⚠️ MAINNET, real funds. SDK is v0.0.3. BTC pool liquidity may be absent — a
+ * quote with 0 output throws instead of returning a confirmable zero.
+ */
+
+import { createMagi, createDefaultPoolProvider, CoinAmount, MAINNET_CONFIG, type MagiClient } from "@vsc.eco/crosschain-sdk";
+
+export type MagiAssetIn = "HIVE" | "HBD";
+export type MagiAssetOut = "BTC";
+const DECIMALS: Record<string, number> = { HIVE: 3, HBD: 3, BTC: 8 };
+
+/** Bitcoin address sanity check (legacy / P2SH / bech32) — rejects xpub/zpub. */
+export const BTC_ADDRESS_RE = /^(bc1[ac-hj-np-z02-9]{25,62}|[13][a-km-zA-HJ-NP-Z1-9]{25,39})$/;
+export const isValidBtcAddress = (a: string) => BTC_ADDRESS_RE.test((a || "").trim());
+
+/** Create a Magi client bound to the app's Aioha (for signing via quickSwap). */
+export function getMagiClient(aioha: unknown): MagiClient {
+  return createMagi({ config: MAINNET_CONFIG, pools: createDefaultPoolProvider(), aioha: aioha as never });
+}
+
+function fmtUnits(raw: bigint, decimals: number): string {
+  const neg = raw < 0n;
+  const s = (neg ? -raw : raw).toString().padStart(decimals + 1, "0");
+  const whole = s.slice(0, s.length - decimals) || "0";
+  const frac = s.slice(s.length - decimals).replace(/0+$/, "");
+  return `${neg ? "-" : ""}${whole}${frac ? "." + frac : ""}`;
+}
+
+export interface MagiSwapInput {
+  username: string;
+  assetIn: MagiAssetIn;
+  assetOut: MagiAssetOut;
+  amountIn: string;
+  recipient: string;
+  slippagePct?: number;
+}
+
+function toSdkInput(p: MagiSwapInput) {
+  return {
+    username: p.username,
+    assetIn: p.assetIn,
+    amountIn: CoinAmount.fromDecimal(p.amountIn, p.assetIn),
+    assetOut: p.assetOut,
+    recipient: p.recipient.trim(),
+    slippageBps: Math.round((p.slippagePct ?? 0.5) * 100),
+  };
+}
+
+export interface MagiPreview {
+  expectedOut: string;
+  minOut: string;
+  hops: number;
+}
+
+/** Quote only (no signing). Throws when the pool has no liquidity (0 output). */
+export async function getMagiPreview(client: MagiClient, p: MagiSwapInput): Promise<MagiPreview> {
+  if (p.assetIn !== "HIVE" && p.assetIn !== "HBD") throw new Error("Magi input must be HIVE or HBD");
+  if (!isValidBtcAddress(p.recipient)) throw new Error("Enter a valid Bitcoin address");
+  if (!(Number(p.amountIn) > 0)) throw new Error("Enter an amount");
+  const build = await client.buildQuickSwap(toSdkInput(p));
+  if (!(build.preview.expectedOutput > 0n)) {
+    throw new Error("Magi has no BTC liquidity for this pair right now — try again later");
+  }
+  const dec = DECIMALS[p.assetOut];
+  return {
+    expectedOut: fmtUnits(build.preview.expectedOutput, dec),
+    minOut: fmtUnits(build.preview.minAmountOut, dec),
+    hops: build.preview.hops,
+  };
+}
+
+/** Execute: builds (with RC sim) + signs + broadcasts via the client's Aioha. */
+export async function executeMagiSwap(client: MagiClient, p: MagiSwapInput): Promise<string> {
+  if (!isValidBtcAddress(p.recipient)) throw new Error("Enter a valid Bitcoin address");
+  const res = await client.quickSwap(toSdkInput(p));
+  return res.txId;
+}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
     "@uiw/react-markdown-preview": "^5.1.4",
     "@uiw/react-md-editor": "^4.0.7",
     "@vercel/postgres": "^0.10.0",
+    "@vsc.eco/crosschain-core": "^0.0.3",
+    "@vsc.eco/crosschain-sdk": "^0.0.3",
     "@wagmi/cli": "^2.3.1",
     "@wagmi/core": "^2.17.2",
     "argon2": "^0.44.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,12 @@ importers:
       '@vercel/postgres':
         specifier: ^0.10.0
         version: 0.10.0(utf-8-validate@6.0.6)
+      '@vsc.eco/crosschain-core':
+        specifier: ^0.0.3
+        version: 0.0.3
+      '@vsc.eco/crosschain-sdk':
+        specifier: ^0.0.3
+        version: 0.0.3(@aioha/aioha@1.8.2(webextension-polyfill@0.10.0))
       '@wagmi/cli':
         specifier: ^2.3.1
         version: 2.10.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -2859,6 +2865,17 @@ packages:
     resolution: {integrity: sha512-fSD23DxGND40IzSkXjcFcxr53t3Tiym59Is0jSYIFpG4/0f0KO9SGtcp1sXiebvPaGe7N/tU05cH4yt2S6/IPg==}
     engines: {node: '>=18.14'}
     deprecated: '@vercel/postgres is deprecated. If you are setting up a new database, you can choose an alternate storage solution from the Vercel Marketplace. If you had an existing Vercel Postgres database, it should have been migrated to Neon as a native Vercel integration. You can find more details and the guide to migrate to Neon''s SDKs here: https://neon.com/docs/guides/vercel-postgres-transition-guide'
+
+  '@vsc.eco/crosschain-core@0.0.3':
+    resolution: {integrity: sha512-ZumGOwoVP04etO5m/3mGd5jbb9oais1OFFMll6sj8RFlE/zfCunRwQ5N3HJS5aXPTSy3248Q4XZkQ/b157Sq8Q==}
+
+  '@vsc.eco/crosschain-sdk@0.0.3':
+    resolution: {integrity: sha512-/8k1n4WoA2JDoKk7/dV8bj8b/DcZApDo5fPdm4HhH+pCsW3j6m8g3Hd8EW8CWGwLhruy5cCKkLZjA3XgF/wYow==}
+    peerDependencies:
+      '@aioha/aioha': ^1.8.0
+    peerDependenciesMeta:
+      '@aioha/aioha':
+        optional: true
 
   '@wagmi/cli@2.10.0':
     resolution: {integrity: sha512-2tYt6Bp1q26mWexH+XE6dMpPB5/Gp/3OVtE2SeeJ/gNHKLZmVF/TuoZR75mpJKTpofyvpz/fnuMCkUxzbc/kRw==}
@@ -10982,6 +10999,14 @@ snapshots:
       ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - utf-8-validate
+
+  '@vsc.eco/crosschain-core@0.0.3': {}
+
+  '@vsc.eco/crosschain-sdk@0.0.3(@aioha/aioha@1.8.2(webextension-polyfill@0.10.0))':
+    dependencies:
+      '@vsc.eco/crosschain-core': 0.0.3
+    optionalDependencies:
+      '@aioha/aioha': 1.8.2(webextension-polyfill@0.10.0)
 
   '@wagmi/cli@2.10.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:


### PR DESCRIPTION
Adds a **BTC / L2** tab to the /wallet swap section:
- **Hive-Engine** diesel-pool swaps (SWAP.HIVE/HBD/BTC, multi-hop via SWAP.HIVE in one tx).
- **Magi (VSC)** cross-chain HIVE/HBD → real BTC (routes through HBD).

Both sign with the app's existing **Aioha** (`signAndBroadcastTx` / `quickSwap`). New lib: `lib/hive/hiveEngine.ts`, `lib/hive/magi.ts`; new `components/wallet/CrossChainSwapPanel.tsx`. Deps: `@vsc.eco/crosschain-sdk`+`crosschain-core` (pnpm).

**Caveats:** mainnet, real funds. Magi SDK is v0.0.3 and SWAP.BTC / Magi-BTC liquidity is currently thin/absent — quotes reflect the real rate and block zero-output; BTC address is validated. `tsc` clean; **not yet browser-tested against a funded wallet** — test with small amounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a BTC/L2 swap tab for Hive users.
  * Enabled Hive-Engine token swaps with live quotes, route selection, slippage protection, and balance validation.
  * Enabled HIVE/HBD-to-BTC swaps with recipient address validation and quote previews.
  * Added transaction status feedback, error notifications, and automatic form reset after successful swaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->