### PR TITLE
fix(magi): port the two swaps.pro fixes — pools load + no pre-deposit sim block

### DIFF
--- a/components/wallet/CrossChainSwapPanel.tsx
+++ b/components/wallet/CrossChainSwapPanel.tsx
@@ -147,7 +147,7 @@ export default function CrossChainSwapPanel() {
     if (!mAddrOk) return notify("Enter a valid Bitcoin address");
     setMBusy(true);
     try {
-      const txId = await executeMagiSwap(magiClient, { username: user, assetIn: mIn, assetOut: "BTC", amountIn: mAmount, recipient: mAddr, slippagePct: 0.5 });
+      const txId = await executeMagiSwap(magiClient, aioha, { username: user, assetIn: mIn, assetOut: "BTC", amountIn: mAmount, recipient: mAddr, slippagePct: 0.5 });
       notify(`Magi swap submitted (tx ${txId.slice(0, 8)}…) — BTC settles shortly`, "success");
       setMAmount("");
       setMPreview(null);

--- a/lib/hive/magi.ts
+++ b/lib/hive/magi.ts
@@ -9,6 +9,14 @@
  */
 
 import { createMagi, createDefaultPoolProvider, CoinAmount, MAINNET_CONFIG, type MagiClient } from "@vsc.eco/crosschain-sdk";
+import { withSwapOpRcLimit } from "@vsc.eco/crosschain-core";
+import { KeyTypes } from "@aioha/aioha";
+
+/** Minimal Aioha surface we need to broadcast the [deposit, swap] ops ourselves. */
+type AiohaLike = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  signAndBroadcastTx: (ops: any[], keyType: any) => Promise<{ success: boolean; result?: string; error?: string }>;
+};
 
 export type MagiAssetIn = "HIVE" | "HBD";
 export type MagiAssetOut = "BTC";
@@ -20,7 +28,14 @@ export const isValidBtcAddress = (a: string) => BTC_ADDRESS_RE.test((a || "").tr
 
 /** Create a Magi client bound to the app's Aioha (for signing via quickSwap). */
 export function getMagiClient(aioha: unknown): MagiClient {
-  return createMagi({ config: MAINNET_CONFIG, pools: createDefaultPoolProvider(), aioha: aioha as never });
+  // IMPORTANT: pass the indexer URL. createDefaultPoolProvider() with no indexerUrl
+  // returns EMPTY pools (SDK: `const entries = indexerUrl ? … : []`), so every quote
+  // comes back expectedOutput=0 and looks like "no liquidity" — it isn't.
+  return createMagi({
+    config: MAINNET_CONFIG,
+    pools: createDefaultPoolProvider(undefined, MAINNET_CONFIG.indexerUrl),
+    aioha: aioha as never,
+  });
 }
 
 function fmtUnits(raw: bigint, decimals: number): string {
@@ -74,9 +89,52 @@ export async function getMagiPreview(client: MagiClient, p: MagiSwapInput): Prom
   };
 }
 
-/** Execute: builds (with RC sim) + signs + broadcasts via the client's Aioha. */
-export async function executeMagiSwap(client: MagiClient, p: MagiSwapInput): Promise<string> {
+/**
+ * Execute a Magi swap: build the [deposit, swap] ops, gate on the checks that
+ * actually matter, and broadcast atomically via Aioha.
+ *
+ * We do NOT use `client.quickSwap` — it hard-throws on `checkSwapRc.!simOk`, and
+ * that sim runs the swap op against the CURRENT VSC ledger, which can't see the
+ * deposit op riding in the SAME broadcast (ops[0]). The VSC node credits the
+ * deposit synchronously before the swap op executes, so the atomic broadcast
+ * succeeds — the sim's `ledger_error: insufficient balance` is a false negative
+ * for any account without a pre-existing VSC balance (i.e. every first-time
+ * swapper). Verified end-to-end on mainnet (2 HBD → BTC settled on-chain).
+ */
+export async function executeMagiSwap(client: MagiClient, aioha: AiohaLike, p: MagiSwapInput): Promise<string> {
   if (!isValidBtcAddress(p.recipient)) throw new Error("Enter a valid Bitcoin address");
-  const res = await client.quickSwap(toSdkInput(p));
-  return res.txId;
+
+  const build = await client.buildQuickSwap(toSdkInput(p));
+  if (!(build.preview.expectedOutput > 0n)) {
+    throw new Error("Magi has no BTC liquidity for this pair right now — try again later");
+  }
+
+  // The real, knowable pre-broadcast gate (the VSC sim can't see Hive L1): does the
+  // user hold enough LIQUID HIVE/HBD for the deposit? (savings/staked don't count.)
+  const needRaw = CoinAmount.fromDecimal(p.amountIn, p.assetIn).raw;
+  const l1 = await client.getBalance(p.username, p.assetIn);
+  if (l1 !== null && l1 < needRaw) {
+    throw new Error(`Not enough liquid ${p.assetIn} — need ${p.amountIn}, have ${fmtUnits(l1, DECIMALS[p.assetIn])} (savings can't be swapped directly)`);
+  }
+
+  // RC + sim gate: bypass ONLY the pre-deposit ledger false-negative; still fail on
+  // any other sim error and on real RC shortfalls.
+  const rc = await client.checkSwapRc({ username: p.username, build });
+  const preDepositGap = !rc.simOk && rc.err === "ledger_error" && /insufficient balance/i.test(rc.errMsg ?? "");
+  if (!rc.simOk && !preDepositGap) {
+    throw new Error(rc.errMsg || rc.err || "Magi simulation failed — try again");
+  }
+  if (rc.simOk && !rc.sufficient) {
+    throw new Error("Not enough Resource Credits for this swap — power up HIVE or wait for RC to recharge.");
+  }
+
+  // Size the swap op's rc_limit from the sim only when the sim actually ran; otherwise
+  // keep the SDK's default (a broadcastRcLimit from an aborted sim is meaningless).
+  const ops = [...build.ops];
+  if (rc.simOk) ops[ops.length - 1] = withSwapOpRcLimit(ops[ops.length - 1], rc.broadcastRcLimit);
+
+  // Atomic broadcast: VSC processes deposit → swap in order within this one Hive tx.
+  const res = await aioha.signAndBroadcastTx(ops, KeyTypes.Active);
+  if (!res?.success) throw new Error(res?.error || "Broadcast rejected");
+  return res.result || "";
 }


### PR DESCRIPTION
Ports the two Magi fixes that were proven **end-to-end on swaps.pro** (verified with real funds: 2 HBD → BTC settled on-chain, Bitcoin block 961514). skatehive's `lib/hive/magi.ts` had the same two bugs.

### 1. Empty pools → false "no liquidity"
`getMagiClient` called `createDefaultPoolProvider()` with **no indexer URL** → the SDK returns an **empty** pool set (`const entries = indexerUrl ? … : []`), so every quote came back `expectedOutput=0`. **Fix:** pass `MAINNET_CONFIG.indexerUrl`.

### 2. `quickSwap` blocks every first-time swapper
`executeMagiSwap` used `client.quickSwap`, which hard-throws on `checkSwapRc.!simOk`. That sim runs the swap op against the **current** VSC ledger and can't see the deposit op in the **same** broadcast (`ops[0]`). The VSC node credits the deposit *before* the swap op executes (traced through `go-vsc-node`), so the atomic tx succeeds — the `ledger_error: insufficient balance` is a **false negative** for anyone without a pre-existing VSC balance (i.e. every first-time swapper).

**Fix:** refactor to `buildQuickSwap` + broadcast the `[deposit, swap]` ops via **Aioha** directly (matching the panel's existing Hive-Engine broadcast), with:
- a **real Hive-L1 liquid-balance** check (the VSC sim can't see L1),
- bypass **only** the pre-deposit `ledger_error: insufficient balance`, still failing on any other sim error + real RC shortfalls,
- sim-derived `rc_limit` applied only when the sim actually ran.

`executeMagiSwap(client, aioha, p)` now takes the panel's `aioha` (already in scope). Typecheck clean.

⚠️ **Money path — please test a small real swap** (e.g. 1–2 HBD → BTC) on skatehive before relying on it, same as we did on swaps.pro. Risk if a swap fails *after* the deposit lands: HBD stays in the VSC ledger (recoverable via `vsc.withdraw`, no SDK helper yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated cross-chain swap execution to provide a more reliable signing and broadcast experience.
  * Added checks for available liquidity, liquid balance, and transaction resource requirements before submitting swaps.
  * Swap transactions can now apply appropriate resource limits automatically.
  * Improved atomic handling of swap operations to help prevent incomplete submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->