### PR TITLE
fix(magi): bring HIVE/HBD→BTC swap up to swapspro (indexer, sim false-negatives, RC gate, never-throw quote)

### DIFF
--- a/components/wallet/CrossChainSwapPanel.tsx
+++ b/components/wallet/CrossChainSwapPanel.tsx
@@ -15,10 +15,11 @@ import {
   type HeQuote,
 } from "@/lib/hive/hiveEngine";
 import {
-  executeMagiSwap,
   getMagiClient,
   getMagiPreview,
   isValidBtcAddress,
+  clampDecimalString,
+  magiInputDecimals,
   type MagiAssetIn,
   type MagiPreview,
 } from "@/lib/hive/magi";
@@ -141,14 +142,26 @@ export default function CrossChainSwapPanel() {
   }, [quoteMagi]);
 
   const doMagiSwap = async () => {
-    if (!magiClient || !user || !mPreview) return;
-    const bal = mIn === "HIVE" ? hiveBalance : hbdBalance;
-    if (Number(mAmount) > bal) return notify(`Insufficient ${mIn}`);
+    // A blocked quote (insufficient balance / RC / unsafe sim) still shows the
+    // BTC output but must never broadcast — the deposit would strand.
+    if (!user || !aioha || !mPreview || mPreview.blockReason) return;
     if (!mAddrOk) return notify("Enter a valid Bitcoin address");
     setMBusy(true);
     try {
-      const txId = await executeMagiSwap(magiClient, { username: user, assetIn: mIn, assetOut: "BTC", amountIn: mAmount, recipient: mAddr, slippagePct: 0.5 });
-      notify(`Magi swap submitted (tx ${txId.slice(0, 8)}…) — BTC settles shortly`, "success");
+      // Broadcast the pre-built [deposit, swap] ops ourselves (NOT client.quickSwap,
+      // whose internal pre-deposit sim always false-negatives). Same Aioha path as L2.
+      const res = await aioha.signAndBroadcastTx(
+        mPreview.ops as Parameters<typeof aioha.signAndBroadcastTx>[0],
+        KeyTypes.Active
+      );
+      if ((res as { success?: boolean })?.success === false) {
+        throw new Error((res as { error?: string })?.error || "Rejected");
+      }
+      const txId = String((res as { result?: unknown })?.result ?? "");
+      notify(
+        `Magi swap submitted${txId ? ` (tx ${txId.slice(0, 8)}…)` : ""} — BTC settles shortly`,
+        "success"
+      );
       setMAmount("");
       setMPreview(null);
     } catch (e) {
@@ -237,7 +250,7 @@ export default function CrossChainSwapPanel() {
             ))}
           </HStack>
           <Text {...eyebrow}>Amount · bal {(mIn === "HIVE" ? hiveBalance : hbdBalance).toFixed(3)}</Text>
-          <Input placeholder="0.0" value={mAmount} onChange={(e) => setMAmount(e.target.value)} type="number" sx={fieldSx} />
+          <Input placeholder="0.0" value={mAmount} onChange={(e) => setMAmount(clampDecimalString(e.target.value, magiInputDecimals(mIn)))} type="number" sx={fieldSx} />
           <Text {...eyebrow}>Your Bitcoin address</Text>
           <Input placeholder="bc1… / 1… / 3…" value={mAddr} onChange={(e) => setMAddr(e.target.value)} sx={{ ...fieldSx, borderColor: mAddr && !mAddrOk ? "red.400" : "primary" }} />
           {mAddr && !mAddrOk && <Text fontSize="10px" color="red.400" fontFamily="mono">Not a valid Bitcoin address (not an xpub/zpub).</Text>}
@@ -247,9 +260,14 @@ export default function CrossChainSwapPanel() {
             </Text>
             {mPreview && <Text fontSize="xs" fontFamily="mono" color="primary" opacity={0.6}>min {mPreview.minOut}</Text>}
           </HStack>
+          {mPreview?.blockReason && (
+            <Text fontSize="10px" fontFamily="mono" color="red.400">
+              {mPreview.blockDetail || mPreview.blockReason}
+            </Text>
+          )}
           <Text fontSize="10px" fontFamily="mono" color="primary" opacity={0.6}>Mainnet · signs two Hive ops. Magi settles BTC to your address after its confirmations. (SDK v0.0.3 — start small.)</Text>
-          <Button bg="primary" color="background" fontFamily="mono" borderRadius="none" isDisabled={!mPreview || mBusy || !mAddrOk} isLoading={mBusy} onClick={doMagiSwap}>
-            {mBusy ? <Spinner size="sm" /> : "Swap to BTC"}
+          <Button bg="primary" color="background" fontFamily="mono" borderRadius="none" isDisabled={!mPreview || mBusy || !mAddrOk || !!mPreview?.blockReason} isLoading={mBusy} onClick={doMagiSwap}>
+            {mBusy ? <Spinner size="sm" /> : mPreview?.blockReason ? mPreview.blockReason : "Swap to BTC"}
           </Button>
         </VStack>
       )}

--- a/components/wallet/CrossChainSwapPanel.tsx
+++ b/components/wallet/CrossChainSwapPanel.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Button, HStack, Input, Spinner, Text, VStack, useToast } from "@chakra-ui/react";
 import { FaBitcoin, FaLayerGroup } from "react-icons/fa";
 import { useAioha } from "@aioha/react-ui";
 import { KeyTypes } from "@aioha/aioha";
 import useHiveAccount from "@/hooks/useHiveAccount";
 import { extractNumber } from "@/lib/utils/extractNumber";
+import { migrateLegacyMetadata } from "@/lib/utils/metadataMigration";
 import {
   buildHeSwapOp,
   getHeBalances,
@@ -120,6 +121,26 @@ export default function CrossChainSwapPanel() {
   const [mErr, setMErr] = useState<string | null>(null);
 
   const mAddrOk = isValidBtcAddress(mAddr);
+
+  // The user's saved Bitcoin address (Hive extensions.wallets.btc_address).
+  // Pre-fill the recipient with it once, while the field is still empty — they
+  // can still overwrite it. Saves re-typing a BTC address on every swap.
+  const registeredBtc = useMemo(() => {
+    const raw = hiveAccount?.json_metadata;
+    if (!raw) return "";
+    try {
+      return migrateLegacyMetadata(JSON.parse(raw))?.extensions?.wallets?.btc_address || "";
+    } catch {
+      return "";
+    }
+  }, [hiveAccount?.json_metadata]);
+  const prefilledAddrRef = useRef(false);
+  useEffect(() => {
+    if (!prefilledAddrRef.current && registeredBtc && !mAddr) {
+      setMAddr(registeredBtc);
+      prefilledAddrRef.current = true;
+    }
+  }, [registeredBtc, mAddr]);
 
   const quoteMagi = useCallback(async () => {
     setMPreview(null);
@@ -254,6 +275,9 @@ export default function CrossChainSwapPanel() {
           <Text {...eyebrow}>Your Bitcoin address</Text>
           <Input placeholder="bc1… / 1… / 3…" value={mAddr} onChange={(e) => setMAddr(e.target.value)} sx={{ ...fieldSx, borderColor: mAddr && !mAddrOk ? "red.400" : "primary" }} />
           {mAddr && !mAddrOk && <Text fontSize="10px" color="red.400" fontFamily="mono">Not a valid Bitcoin address (not an xpub/zpub).</Text>}
+          {registeredBtc && mAddr === registeredBtc && mAddrOk && (
+            <Text fontSize="10px" fontFamily="mono" color="primary" opacity={0.6}>Using your saved Bitcoin address — edit above to send elsewhere.</Text>
+          )}
           <HStack justify="space-between" minH="18px">
             <Text fontSize="xs" fontFamily="mono" color="primary" opacity={0.7}>
               {mQuoting ? "quoting…" : mPreview ? `≈ ${mPreview.expectedOut} BTC` : mErr || ""}

--- a/components/wallet/CrossChainSwapPanel.tsx
+++ b/components/wallet/CrossChainSwapPanel.tsx
@@ -26,7 +26,10 @@ import {
 } from "@/lib/hive/magi";
 
 type SubMode = "l2" | "btc";
-const L2_SYMBOLS = HE_ASSETS.map((a) => a.symbol); // SWAP.HIVE / SWAP.HBD / SWAP.BTC
+// SWAP.BTC dropped from the L2 tab: its diesel pool is thin (~0.5 wrapped BTC)
+// and only yields SWAP.BTC (a Hive-Engine token, not real BTC — needs a gateway
+// withdrawal). The "→ Bitcoin (Magi)" tab routes to real BTC instead.
+const L2_SYMBOLS = HE_ASSETS.map((a) => a.symbol).filter((s) => s !== "SWAP.BTC");
 
 /**
  * Hive-Engine (L2 diesel-pool) swaps + Magi cross-chain HIVE/HBD → BTC, signed
@@ -67,7 +70,7 @@ export default function CrossChainSwapPanel() {
 
   // ---- Hive-Engine (L2) ----------------------------------------------------
   const [l2Sell, setL2Sell] = useState("SWAP.HBD");
-  const [l2Buy, setL2Buy] = useState("SWAP.BTC");
+  const [l2Buy, setL2Buy] = useState("SWAP.HIVE");
   const [l2Amount, setL2Amount] = useState("");
   const [l2Quote, setL2Quote] = useState<HeQuote | null>(null);
   const [l2Quoting, setL2Quoting] = useState(false);
@@ -253,9 +256,6 @@ export default function CrossChainSwapPanel() {
             </Text>
             {l2Quote && <Text fontSize="xs" fontFamily="mono" color="primary" opacity={0.6}>min {l2Quote.minOut.toFixed(8)}</Text>}
           </HStack>
-          {l2Buy === "SWAP.BTC" && (
-            <Text fontSize="10px" fontFamily="mono" color="primary" opacity={0.6}>SWAP.BTC pools are thin — rate can be poor. To reach real BTC, withdraw SWAP.BTC via the Hive-Engine gateway.</Text>
-          )}
           <Button bg="primary" color="background" fontFamily="mono" borderRadius="none" isDisabled={!l2Quote || l2Busy} isLoading={l2Busy} onClick={doL2Swap}>
             Swap
           </Button>

--- a/components/wallet/UnifiedWalletTable.tsx
+++ b/components/wallet/UnifiedWalletTable.tsx
@@ -296,11 +296,12 @@ function SendPickerModal({ isOpen, onClose, consolidatedTokens, onSelect, requir
 }
 
 // ─── Receive Modal ────────────────────────────────────────────────────────────
-function ReceiveModal({ isOpen, onClose, hiveUser, evmAddress }: {
+function ReceiveModal({ isOpen, onClose, hiveUser, evmAddress, btcAddress }: {
   isOpen: boolean;
   onClose: () => void;
   hiveUser?: string;
   evmAddress?: string;
+  btcAddress?: string;
 }) {
   const toast = useToast();
   const copy = (val: string) => {
@@ -339,7 +340,16 @@ function ReceiveModal({ isOpen, onClose, hiveUser, evmAddress }: {
                 </HStack>
               </Box>
             )}
-            {!hiveUser && !evmAddress && (
+            {btcAddress && (
+              <Box>
+                <Text fontSize="xs" color="dim" fontFamily="mono" textTransform="uppercase" mb={1}>Bitcoin Address</Text>
+                <HStack border="1px solid" borderColor="border" p={3}>
+                  <Text fontFamily="mono" fontSize="xs" color="primary" flex={1} wordBreak="break-all">{btcAddress}</Text>
+                  <IconButton aria-label="Copy" icon={<FaCopy />} size="xs" variant="ghost" color="dim" onClick={() => copy(btcAddress)} />
+                </HStack>
+              </Box>
+            )}
+            {!hiveUser && !evmAddress && !btcAddress && (
               <Text fontFamily="mono" fontSize="sm" color="dim" textAlign="center">
                 No linked addresses found.
               </Text>
@@ -656,6 +666,7 @@ export default function UnifiedWalletTable({
         onClose={onReceiveClose}
         hiveUser={hiveUser}
         evmAddress={address}
+        btcAddress={btcAddress}
       />
     </Box>
   );

--- a/lib/hive/magi.ts
+++ b/lib/hive/magi.ts
@@ -1,28 +1,83 @@
 /**
  * Magi (VSC) cross-chain swaps for skatehive — HIVE/HBD → real BTC, routed
- * through HBD. Ported from swapspro; here we pass the app's Aioha instance to
- * `createMagi`, so `client.quickSwap` signs + broadcasts via Aioha directly
- * (the ops are Hive transfer/custom_json).
+ * through HBD. Ported from swapspro (coinmastersguild/swapspro), adapted from
+ * its Keychain/KeepKey signer to skatehive's Aioha signer.
  *
- * ⚠️ MAINNET, real funds. SDK is v0.0.3. BTC pool liquidity may be absent — a
- * quote with 0 output throws instead of returning a confirmable zero.
+ * `buildQuickSwap` returns two Hive ops ([deposit, swap]) that we broadcast
+ * OURSELVES via Aioha (`aioha.signAndBroadcastTx(preview.ops, KeyTypes.Active)`)
+ * — we do NOT call `client.quickSwap()`, because its internal path gates on the
+ * pre-deposit RC simulation, which is ALWAYS a false negative for a real swap
+ * (see the RC gating below). Gating lives here so a can't-trade condition
+ * disables the button with a reason instead of throwing.
+ *
+ * ⚠️ MAINNET — moves real funds. SDK v0.0.3; test with small amounts first.
  */
 
-import { createMagi, createDefaultPoolProvider, CoinAmount, MAINNET_CONFIG, type MagiClient } from "@vsc.eco/crosschain-sdk";
+import {
+  createMagi,
+  createDefaultPoolProvider,
+  CoinAmount,
+  MAINNET_CONFIG,
+  simCallFromSwapOp,
+  type MagiClient,
+} from "@vsc.eco/crosschain-sdk";
+import { withSwapOpRcLimit } from "@vsc.eco/crosschain-core";
 
 export type MagiAssetIn = "HIVE" | "HBD";
 export type MagiAssetOut = "BTC";
 const DECIMALS: Record<string, number> = { HIVE: 3, HBD: 3, BTC: 8 };
 
+/** On-chain decimal precision for a Magi sell asset (HIVE/HBD are 3-dp). */
+export const magiInputDecimals = (asset: MagiAssetIn): number => DECIMALS[asset] ?? 3;
+
 /** Bitcoin address sanity check (legacy / P2SH / bech32) — rejects xpub/zpub. */
 export const BTC_ADDRESS_RE = /^(bc1[ac-hj-np-z02-9]{25,62}|[13][a-km-zA-HJ-NP-Z1-9]{25,39})$/;
 export const isValidBtcAddress = (a: string) => BTC_ADDRESS_RE.test((a || "").trim());
 
-/** Create a Magi client bound to the app's Aioha (for signing via quickSwap). */
-export function getMagiClient(aioha: unknown): MagiClient {
-  return createMagi({ config: MAINNET_CONFIG, pools: createDefaultPoolProvider(), aioha: aioha as never });
+// ── Decimal precision helpers (ported from swapspro amounts.ts) ─────────────
+// HIVE/HBD are 3-dp on-chain; feeding 4+ dp to CoinAmount.fromDecimal throws
+// ("too many decimals"). A quote/input must never fail on a formatting detail.
+
+/** Trim a (possibly mid-typing) numeric string to at most `maxDecimals` places
+ *  without rounding — keeps "12", "12." and "12.3" intact but blocks a 4th
+ *  decimal on a 3-dp asset. Use on the amount field's onChange. */
+export function clampDecimalString(value: string, maxDecimals: number): string {
+  const dot = value.indexOf(".");
+  if (dot < 0) return value;
+  if (maxDecimals <= 0) return value.slice(0, dot);
+  return value.slice(0, dot + 1 + maxDecimals);
 }
 
+/** Truncate a numeric amount to at most `maxDecimals` places (never rounds up,
+ *  so the result can't exceed the user's balance). */
+export function truncateToDecimals(value: number, maxDecimals: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "0";
+  const factor = 10 ** maxDecimals;
+  const truncated = Math.floor(value * factor) / factor;
+  return String(Number(truncated.toFixed(maxDecimals)));
+}
+
+/**
+ * Create a Magi client. IMPORTANT: pass the indexer URL — `createDefaultPoolProvider()`
+ * with no indexerUrl returns an EMPTY pool set (SDK: `const entries = indexerUrl ? … : []`),
+ * which makes every quote come back expectedOutput=0 and look like "no liquidity" when it
+ * isn't. Aioha is passed through for compatibility but signing is done by the caller
+ * (we broadcast the built ops ourselves rather than via `quickSwap`).
+ */
+export function getMagiClient(aioha: unknown): MagiClient {
+  return createMagi({
+    config: MAINNET_CONFIG,
+    pools: createDefaultPoolProvider(undefined, MAINNET_CONFIG.indexerUrl),
+    aioha: aioha as never,
+  });
+}
+
+/** VSC resource-credit amount → compact "k" string for messages. */
+function fmtRc(rc: bigint): string {
+  return `${(Number(rc) / 1000).toFixed(1)}k`;
+}
+
+/** Smallest-unit bigint → human decimal string (trims trailing zeros). */
 function fmtUnits(raw: bigint, decimals: number): string {
   const neg = raw < 0n;
   const s = (neg ? -raw : raw).toString().padStart(decimals + 1, "0");
@@ -40,43 +95,106 @@ export interface MagiSwapInput {
   slippagePct?: number;
 }
 
-function toSdkInput(p: MagiSwapInput) {
-  return {
-    username: p.username,
-    assetIn: p.assetIn,
-    amountIn: CoinAmount.fromDecimal(p.amountIn, p.assetIn),
-    assetOut: p.assetOut,
-    recipient: p.recipient.trim(),
-    slippageBps: Math.round((p.slippagePct ?? 0.5) * 100),
-  };
-}
+/** The [deposit, swap] Hive ops produced by buildQuickSwap, to be broadcast via Aioha. */
+type MagiOps = Awaited<ReturnType<MagiClient["buildQuickSwap"]>>["ops"];
 
 export interface MagiPreview {
   expectedOut: string;
   minOut: string;
   hops: number;
+  /** Non-fatal reason the swap can't execute right now (insufficient balance /
+   *  RC / unsafe sim). When set, the UI shows the output but disables the CTA. */
+  blockReason?: string;
+  blockDetail?: string;
+  /** The ops to sign+broadcast via `aioha.signAndBroadcastTx(ops, KeyTypes.Active)`. */
+  ops: MagiOps;
 }
 
-/** Quote only (no signing). Throws when the pool has no liquidity (0 output). */
+/**
+ * Quote HIVE/HBD → BTC through Magi + decide tradeable vs blocked. Only a truly
+ * UNPRICEABLE route (empty pool → 0 output) throws; every can't-trade condition
+ * (insufficient liquid balance, insufficient RC, unsafe sim) RETURNS the quote
+ * with the BTC output visible plus a non-fatal `blockReason`. No signing.
+ */
 export async function getMagiPreview(client: MagiClient, p: MagiSwapInput): Promise<MagiPreview> {
   if (p.assetIn !== "HIVE" && p.assetIn !== "HBD") throw new Error("Magi input must be HIVE or HBD");
   if (!isValidBtcAddress(p.recipient)) throw new Error("Enter a valid Bitcoin address");
   if (!(Number(p.amountIn) > 0)) throw new Error("Enter an amount");
-  const build = await client.buildQuickSwap(toSdkInput(p));
+
+  // Truncate to the asset's on-chain precision so an over-precise amount can
+  // never throw in CoinAmount.fromDecimal.
+  const sellAmount = truncateToDecimals(Number(p.amountIn), DECIMALS[p.assetIn]);
+  if (!(Number(sellAmount) > 0)) throw new Error("Enter an amount");
+
+  const build = await client.buildQuickSwap({
+    username: p.username,
+    assetIn: p.assetIn,
+    amountIn: CoinAmount.fromDecimal(sellAmount, p.assetIn),
+    assetOut: p.assetOut,
+    recipient: p.recipient.trim(),
+    slippageBps: Math.round((p.slippagePct ?? 0.5) * 100),
+  });
+
+  // The ONLY fatal case: an empty/unpriceable pool returns 0 output — no rate to show.
   if (!(build.preview.expectedOutput > 0n)) {
     throw new Error("Magi has no BTC liquidity for this pair right now — try again later");
   }
+
+  let blockReason: string | undefined;
+  let blockDetail: string | undefined;
+
+  // 1) Liquid Hive L1 balance must cover the deposit (savings/staked don't count).
+  //    This is the check that actually matters — the VSC sim below looks at the
+  //    VSC ledger, not Hive L1.
+  const needRaw = CoinAmount.fromDecimal(sellAmount, p.assetIn).raw;
+  const l1 = await client.getBalance(p.username, p.assetIn);
+  if (l1 !== null && l1 < needRaw) {
+    blockReason = `Insufficient liquid ${p.assetIn}`;
+    blockDetail = `Need ${sellAmount} ${p.assetIn}, you have ${fmtUnits(l1, DECIMALS[p.assetIn])} liquid (savings can't be swapped directly).`;
+  }
+
+  // 2) RC sufficiency — gate it DIRECTLY. The atomic [deposit, swap] can't be
+  //    simulated pre-broadcast (checkSwapRc runs the swap op against the CURRENT
+  //    VSC ledger, which can't see the deposit riding in ops[0]), so sim RC is a
+  //    false negative. The account must hold at least the swap op's declared
+  //    rc_limit (1e4 for cross-chain, safely above the ~8.2k real cost) or the
+  //    broadcast runs out of RC mid-swap and STRANDS the deposited HBD.
+  const swapCall = simCallFromSwapOp(build.ops[build.ops.length - 1]);
+  const requiredRc = BigInt(swapCall.rc_limit || 10000);
+  const rc = await client.checkSwapRc({ username: p.username, build });
+  if (!blockReason && rc.rcAvailable < requiredRc) {
+    blockReason = "Not enough Resource Credits";
+    blockDetail = `This Magi swap needs about ${fmtRc(requiredRc)} RC and @${p.username} has ${fmtRc(rc.rcAvailable)}. Wait for your RC to recharge, or power up HIVE.`;
+  }
+
+  // A genuine (non-artifact) sim failure means the built ops are unsafe — block
+  // execution but still return the quote. The two artifact faces are the
+  // pre-deposit ledger gap (insufficient balance) and the collapsed sim rc_limit
+  // (cost limit exceeded); neither is a real failure.
+  const isPreDepositArtifact =
+    !rc.simOk &&
+    ((rc.err === "ledger_error" && /insufficient balance/i.test(rc.errMsg ?? "")) ||
+      (rc.err === "gas_limit_hit" && /cost limit exceeded/i.test(rc.errMsg ?? "")));
+  if (!blockReason && !rc.simOk && !isPreDepositArtifact) {
+    blockReason = "Swap can't be simulated";
+    blockDetail = rc.errMsg || rc.err || "Magi couldn't simulate this swap right now — try again.";
+  }
+
+  // Size the swap op's rc_limit from the sim ONLY when it actually ran (funded
+  // account). On the pre-deposit artifact, keep the SDK's default rc_limit — a
+  // limit derived from an aborted sim reflects only the failed attempt.
+  const ops = [...build.ops] as MagiOps;
+  if (rc.simOk) {
+    ops[ops.length - 1] = withSwapOpRcLimit(ops[ops.length - 1], rc.broadcastRcLimit);
+  }
+
   const dec = DECIMALS[p.assetOut];
   return {
     expectedOut: fmtUnits(build.preview.expectedOutput, dec),
     minOut: fmtUnits(build.preview.minAmountOut, dec),
     hops: build.preview.hops,
+    blockReason,
+    blockDetail,
+    ops,
   };
-}
-
-/** Execute: builds (with RC sim) + signs + broadcasts via the client's Aioha. */
-export async function executeMagiSwap(client: MagiClient, p: MagiSwapInput): Promise<string> {
-  if (!isValidBtcAddress(p.recipient)) throw new Error("Enter a valid Bitcoin address");
-  const res = await client.quickSwap(toSdkInput(p));
-  return res.txId;
 }


### PR DESCRIPTION
Ports swapspro's four Magi fixes (PRs #27/#28/#33/#34 there) into skatehive, adapting from swapspro's Keychain/KeepKey signer to skatehive's **Aioha** signer. Real mainnet funds are at stake — one of these bugs can strand user HBD.

## Core architectural change
Stop calling `client.quickSwap()` (its internal path gates on the pre-deposit RC simulation, which **always** false-negatives for a real swap). Instead:
1. `buildQuickSwap()` → `{ ops: [deposit, swap], preview }`
2. Apply gating in `getMagiPreview` (never let the SDK gate)
3. Broadcast the ops ourselves: `aioha.signAndBroadcastTx(preview.ops, KeyTypes.Active)`

## The fixes
1. **Pool indexer (#27):** `createDefaultPoolProvider()` with no `indexerUrl` returns **empty pools** → every quote `expectedOutput=0` → false "no liquidity". Now passes `MAINNET_CONFIG.indexerUrl`.
2. **Pre-deposit sim is a false negative (#28/#33):** the atomic `[deposit, swap]` can't be simulated pre-broadcast (`checkSwapRc` runs the swap op against the current VSC ledger, blind to the deposit in `ops[0]`) → `ledger_error: insufficient balance` / `gas_limit_hit: cost limit exceeded`. Both are artifacts — detected and ignored; real balance gated via Hive L1 `getBalance`.
3. **RC checked directly (#33):** gate on the swap op's declared `rc_limit` (1e4, safely above the measured ~8.2k). An under-RC broadcast strands the deposited HBD (no withdraw helper).
4. **Quote never fails for can't-trade (#34):** only an unpriceable route (empty pool → 0 output) throws; insufficient balance / RC / unsafe sim **return** the quote with BTC output visible + a non-fatal `blockReason`/`blockDetail` that disables the CTA.
5. **Decimals never throw:** ported `truncateToDecimals`/`clampDecimalString`; input clamped to the asset's precision + truncated in the quote builder.

## Verification (read-only, live VSC/Hive — no broadcast)
| account | RC | result |
|---|---|---|
| `@xvlad` | 6.4k | `out=0.00001343 BTC` shown + **"Not enough Resource Credits"** (output visible, CTA disabled) |
| `@starkerz` | ok | clean **tradeable** quote, no block |
| `@hive.fund` | ok | clean **tradeable** quote, no block |

`pnpm tsc --noEmit` + lint clean.

## ⚠️ Not yet done
No real mainnet broadcast has been exercised (needs a funded, adequate-RC Hive account). **Before merge:** one small (~1 HBD) HIVE/HBD→BTC swap from such an account, confirming sats land on the BTC address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Magi swaps now use the previewed transaction details for a more reliable signing flow.
  * Swap previews check available balances, resource credits, and transaction safety before broadcasting.
  * Asset-specific decimal precision is enforced for swap amounts.

* **Bug Fixes**
  * Blocked swaps can no longer be broadcast.
  * The swap button now clearly reflects when a swap is unavailable and displays the reason.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->