### PR TITLE
feat(snaps): thread comments with a connector line

### DIFF
--- a/components/blog/PostPage.tsx
+++ b/components/blog/PostPage.tsx
@@ -133,6 +133,7 @@ export default function PostPage({ author, permlink }: PostPageProps) {
                   newComment={newComment}
                   setNewComment={setNewComment}
                   post={true}
+                  threadComments
                   data={commentsData}
                 />
               </>

--- a/components/homepage/Snap.tsx
+++ b/components/homepage/Snap.tsx
@@ -251,6 +251,9 @@ const Snap = React.memo(function Snap({
   // #00FF00 on the hacker themes, which made the connector read as a bright
   // green rule instead of a quiet hairline between avatars.
   const threadLineColor = useColorModeValue("blackAlpha.400", "whiteAlpha.400");
+  // Media, body and actions share this offset — they have to, or the column
+  // stops lining up with the author name.
+  const contentPl = isCommentRow ? `${THREAD_CONTENT_OFFSET_PX}px` : 0;
 
   const { text, media } = useMemo(
     () => separateContent(discussion.body),
@@ -301,6 +304,18 @@ const Snap = React.memo(function Snap({
   );
   const [votedOverride, setVotedOverride] = useState(false);
   const voted = votedOverride || derivedVoted;
+
+  // Accessible names for the two icon-only controls. Without them a screen
+  // reader announces the bare count, or nothing at all when it is zero. The
+  // count belongs in the label because aria-label replaces the element's own
+  // content. "Upvoted" rather than "Remove upvote": clicking an already-voted
+  // control is a no-op here, so offering to undo would be a lie.
+  const voteLabel = `${voted ? "Upvoted" : "Upvote"}${
+    activeVotes.length > 0 ? `, ${activeVotes.length} votes` : ""
+  }`;
+  const replyLabel = `Reply${
+    commentCount > 0 ? `, ${commentCount} replies` : ""
+  }`;
 
   // Direct vote handler for when slider is disabled
   async function handleDirectVote() {
@@ -459,7 +474,16 @@ const Snap = React.memo(function Snap({
         )}
 
         <Flex align="flex-start" gap={`${THREAD_GUTTER_GAP_PX}px`}>
-          <Box flexShrink={0} width={`${THREAD_AVATAR_PX}px`}>
+          {/* Positioned so the avatar paints above the connector. A positioned
+              element beats non-positioned content in the painting order, so
+              without this the previous row's bleed would land on top of this
+              avatar rather than tucking behind it. */}
+          <Box
+            position="relative"
+            zIndex={1}
+            flexShrink={0}
+            width={`${THREAD_AVATAR_PX}px`}
+          >
             <Link href={profileLink} display="block" _hover={{ textDecoration: "none" }}>
               <Avatar size="sm" name={displayAuthor} src={displayAvatar} />
             </Link>
@@ -554,7 +578,7 @@ const Snap = React.memo(function Snap({
             media there is opaque and hundreds of pixels tall, so it would hide
             the line for that whole stretch and the chain would read as two
             disconnected stubs on any comment carrying a video. */}
-        <Box pl={isCommentRow ? `${THREAD_CONTENT_OFFSET_PX}px` : 0}>
+        <Box pl={contentPl}>
           <MediaRenderer mediaContent={media} fullContent={discussion.body} />
         </Box>
 
@@ -562,7 +586,7 @@ const Snap = React.memo(function Snap({
             what makes a threaded row read as one column. A feed post keeps the
             full width it has on main: nothing threads there, so the avatar
             column would just be an empty strip down the left of every post. */}
-        <Box pl={isCommentRow ? `${THREAD_CONTENT_OFFSET_PX}px` : 0}>
+        <Box pl={contentPl}>
           <Box sx={{ p: { marginBottom: "1rem", lineHeight: "1.6" } }}>
             <EnhancedMarkdownRenderer content={text} />
           </Box>
@@ -586,6 +610,8 @@ const Snap = React.memo(function Snap({
                   cursor="pointer"
                   role="button"
                   tabIndex={0}
+                  aria-label={voteLabel}
+                  aria-disabled={voted || isVoting || undefined}
                   onClick={() => {
                     if (!voted && !isVoting) {
                       if (disableSlider) {
@@ -644,6 +670,8 @@ const Snap = React.memo(function Snap({
                   cursor="pointer"
                   role="button"
                   tabIndex={0}
+                  aria-label={replyLabel}
+                  aria-expanded={isThreadOpen}
                   onClick={() => {
                     // Always open inline composer for replies
                     handleReplyButtonClick(discussion.permlink);

--- a/components/homepage/Snap.tsx
+++ b/components/homepage/Snap.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Text,
+  Flex,
   HStack,
   Button,
   Avatar,
@@ -13,6 +14,7 @@ import {
   Menu,
   MenuList,
   useToast,
+  useColorModeValue,
 } from "@chakra-ui/react";
 import dynamic from "next/dynamic";
 import { DeleteIcon } from "@chakra-ui/icons";
@@ -60,6 +62,25 @@ const SponsorshipModal = dynamic(() => import("@/components/userbase/Sponsorship
 import { useViewerHiveIdentity } from "@/hooks/useViewerHiveIdentity";
 import { FaGift } from "react-icons/fa";
 
+// Thread layout, Farcaster style: the avatar sits in a fixed left gutter and a
+// connector runs down that gutter between rows of the same conversation.
+//
+// Replies are never indented — a reply sits in the same avatar column as the
+// comment it answers, directly beneath it, so the connector between them is
+// straight and centred. An indent would offset the reply's avatar from the
+// column the line runs in and leave the line visibly off to one side. It also
+// makes a runaway cascade impossible: there is no per-level offset to
+// accumulate, however deep the chain goes.
+const THREAD_AVATAR_PX = 32; // matches Chakra Avatar size="sm"
+const THREAD_GUTTER_GAP_PX = 12;
+// Total left offset of the content column. Media cancels this to run edge to
+// edge, so the two have to stay in sync.
+const THREAD_CONTENT_OFFSET_PX = THREAD_AVATAR_PX + THREAD_GUTTER_GAP_PX;
+// How far a connector bleeds past its row to reach the next avatar.
+// Overshooting is safe (the avatar is opaque and covers it); undershooting
+// leaves a visible break in the chain.
+const THREAD_CONNECTOR_BLEED_PX = 24;
+
 interface SnapProps {
   discussion: Discussion;
   onOpen: () => void;
@@ -67,6 +88,19 @@ interface SnapProps {
   setConversation?: (conversation: Discussion) => void;
   onCommentAdded?: () => void;
   onDelete?: (permlink: string) => void;
+  /**
+   * True when another row of the same conversation is rendered directly below
+   * this one, so the connector has to carry on past this row. Set by a reply
+   * group for all but its last reply, and by SnapList for a post's comment
+   * list.
+   */
+  hasFollowingThreadRow?: boolean;
+  /**
+   * True when this row is a comment rather than a top-level post in the feed.
+   * Only comments thread: a feed snap must never draw a connector out of its
+   * author avatar, however many replies it has open.
+   */
+  isCommentRow?: boolean;
 }
 
 const Snap = React.memo(function Snap({
@@ -76,6 +110,8 @@ const Snap = React.memo(function Snap({
   setConversation,
   onCommentAdded,
   onDelete,
+  hasFollowingThreadRow = false,
+  isCommentRow = false,
 }: SnapProps) {
   const { user: walletUser, aioha } = useAioha();
   const { handle: effectiveUser } = useEffectiveHiveUser();
@@ -201,6 +237,20 @@ const Snap = React.memo(function Snap({
   );
 
   const effectiveDepth = discussion.depth || 0;
+
+  const isThreadOpen = Boolean(inlineComposerStates[discussion.permlink]);
+  const inlineReplies = inlineRepliesMap[discussion.permlink] ?? [];
+  // Threading is for comments only. A post in the feed never draws — no line
+  // may leave its author avatar, open replies or not — so the drop into a reply
+  // group is gated on this row being a comment itself. hasFollowingThreadRow is
+  // already comment-only: nothing sets it in the feed.
+  const hasVisibleReplies = isThreadOpen && inlineReplies.length > 0;
+  const showThreadConnector =
+    (isCommentRow && hasVisibleReplies) || hasFollowingThreadRow;
+  // Neutral translucent grey rather than the theme text colour: "text" is
+  // #00FF00 on the hacker themes, which made the connector read as a bright
+  // green rule instead of a quiet hairline between avatars.
+  const threadLineColor = useColorModeValue("blackAlpha.400", "whiteAlpha.400");
 
   const { text, media } = useMemo(
     () => separateContent(discussion.body),
@@ -379,143 +429,164 @@ const Snap = React.memo(function Snap({
   }
 
   return (
-    <Box pl={effectiveDepth > 1 ? 1 : 0} ml={effectiveDepth > 1 ? 2 : 0}>
-      <Box mt={1} mb={1} borderRadius="base" width="100%">
-        <HStack mb={2}>
-          <Link
-            href={profileLink}
-            _hover={{ textDecoration: "none" }}
-            display="flex"
-            alignItems="center"
-            role="group"
-          >
-            <Avatar
-              size="sm"
-              name={displayAuthor}
-              src={displayAvatar}
-              ml={2}
-            />
+    <Box position="relative" width="100%" mt={1} mb={1}>
+      {/* Thread connector: leaves from under the avatar and stops at the next
+          one. Anchored to this wrapper rather than to the reply group, so it
+          ends with the row instead of trailing past the last reply. Only rows
+          with another row after them draw it, so the line begins at the first
+          comment and ends on the last. */}
+      <Box position="relative">
+        {showThreadConnector && (
+          <Box
+            aria-hidden="true"
+            position="absolute"
+            left={`${THREAD_AVATAR_PX / 2}px`}
+            ml="-1px"
+            top={`${THREAD_AVATAR_PX + 4}px`}
+            // The bleed exists to bridge the gap to the next avatar. With the
+            // thread open and nothing fetched yet, what follows is the reply
+            // composer, not an avatar — bleeding into it just leaves a stub
+            // pointing at a text box.
+            bottom={
+              isThreadOpen && !hasVisibleReplies
+                ? 0
+                : `-${THREAD_CONNECTOR_BLEED_PX}px`
+            }
+            width="2px"
+            bg={threadLineColor}
+            borderRadius="full"
+          />
+        )}
+
+        <Flex align="flex-start" gap={`${THREAD_GUTTER_GAP_PX}px`}>
+          <Box flexShrink={0} width={`${THREAD_AVATAR_PX}px`}>
+            <Link href={profileLink} display="block" _hover={{ textDecoration: "none" }}>
+              <Avatar size="sm" name={displayAuthor} src={displayAvatar} />
+            </Link>
+          </Box>
+
+          <Box flex="1" minW={0}>
+          <HStack spacing={2} mb={2}>
+            <Link
+              href={profileLink}
+              _hover={{ textDecoration: "none" }}
+              role="group"
+              minW={0}
+            >
+              <Text
+                fontWeight="medium"
+                fontSize="sm"
+                noOfLines={1}
+                _groupHover={{ textDecoration: "underline" }}
+              >
+                {displayAuthor}
+              </Text>
+            </Link>
             <Text
               fontWeight="medium"
               fontSize="sm"
-              ml={2}
+              color="gray"
               whiteSpace="nowrap"
-              _groupHover={{ textDecoration: "underline" }}
             >
-              {displayAuthor}
+              · {commentDate}
             </Text>
-          </Link>
-          <HStack ml={0} width="100%" justify="space-between">
-            <HStack>
-              <Text fontWeight="medium" fontSize="sm" color="gray">
-                · {commentDate}
-              </Text>
+            <Box ml="auto">
+              <Menu>
+                <MenuButton
+                  as={IconButton}
+                  aria-label="Edit post"
+                  icon={<BiDotsHorizontal />}
+                  size="sm"
+                  variant="ghost"
+                  _active={{ bg: "none" }}
+                  _hover={{ bg: "none" }}
+                  bg={"background"}
+                  color={"primary"}
+                />
+                <MenuList bg={"background"} color={"primary"}>
+                  {canEditThisPost && (
+                    <MenuItem
+                      onClick={handleEditClick}
+                      bg={"background"}
+                      color={"primary"}
+                    >
+                      <SlPencil style={{ marginRight: "8px" }} />
+                      Edit
+                    </MenuItem>
+                  )}
+                  {walletUser === discussion.author && (
+                    <MenuItem
+                      onClick={handleDeleteClick}
+                      bg={"background"}
+                      color={"error"}
+                      isDisabled={isDeleting}
+                    >
+                      <DeleteIcon style={{ marginRight: "8px" }} />
+                      Delete
+                    </MenuItem>
+                  )}
+                  {isModerator && (
+                    <MenuItem
+                      onClick={handleOpenIgPreview}
+                      bg={"background"}
+                      color={"primary"}
+                      isDisabled={!igMedia.has}
+                    >
+                      <FaInstagram style={{ marginRight: "8px" }} />
+                      {igMedia.has
+                        ? "Force post to Instagram…"
+                        : "Force post to Instagram (no media)"}
+                    </MenuItem>
+                  )}
+                  <ShareMenuButtons comment={discussion} />
+                </MenuList>
+              </Menu>
+            </Box>
             </HStack>
-          </HStack>
-          <Menu>
-            <MenuButton
-              as={IconButton}
-              aria-label="Edit post"
-              icon={<BiDotsHorizontal />}
-              size="sm"
-              variant="ghost"
-              _active={{ bg: "none" }}
-              _hover={{ bg: "none" }}
-              bg={"background"}
-              color={"primary"}
-            />
-            <MenuList bg={"background"} color={"primary"}>
-              {canEditThisPost && (
-                <MenuItem
-                  onClick={handleEditClick}
-                  bg={"background"}
-                  color={"primary"}
-                >
-                  <SlPencil style={{ marginRight: "8px" }} />
-                  Edit
-                </MenuItem>
-              )}
-              {walletUser === discussion.author && (
-                <MenuItem
-                  onClick={handleDeleteClick}
-                  bg={"background"}
-                  color={"error"}
-                  isDisabled={isDeleting}
-                >
-                  <DeleteIcon style={{ marginRight: "8px" }} />
-                  Delete
-                </MenuItem>
-              )}
-              {isModerator && (
-                <MenuItem
-                  onClick={handleOpenIgPreview}
-                  bg={"background"}
-                  color={"primary"}
-                  isDisabled={!igMedia.has}
-                >
-                  <FaInstagram style={{ marginRight: "8px" }} />
-                  {igMedia.has
-                    ? "Force post to Instagram…"
-                    : "Force post to Instagram (no media)"}
-                </MenuItem>
-              )}
-              <ShareMenuButtons comment={discussion} />
-            </MenuList>
-          </Menu>
-        </HStack>
-        <Box>
-          <Box>
-            <MediaRenderer mediaContent={media} fullContent={discussion.body} />
           </Box>
-          <Box
-            sx={{
-              p: { marginBottom: "1rem", lineHeight: "1.6", marginLeft: "4" },
-            }}
-          >
-            <EnhancedMarkdownRenderer content={text} />
-          </Box>
+        </Flex>
+
+        {/* Media is a direct child of the snap, exactly as on main: a plain
+            block, no gutter to escape and no negative margin to resolve. A
+            feed post keeps the full width it has always had.
+            A comment indents it into the content column instead, because a
+            threaded row has a connector at x=16 running past it. Full-bleed
+            media there is opaque and hundreds of pixels tall, so it would hide
+            the line for that whole stretch and the chain would read as two
+            disconnected stubs on any comment carrying a video. */}
+        <Box pl={isCommentRow ? `${THREAD_CONTENT_OFFSET_PX}px` : 0}>
+          <MediaRenderer mediaContent={media} fullContent={discussion.body} />
         </Box>
 
-        <EditPostModal
-          isOpen={isEditing}
-          onClose={handleCancelEdit}
-          discussion={discussion}
-          editedContent={editedContent}
-          setEditedContent={setEditedContent}
-          onSave={handleSaveEdit}
-          isSaving={isSaving}
-        />
+        {/* On a comment, body and actions align under the author name, which is
+            what makes a threaded row read as one column. A feed post keeps the
+            full width it has on main: nothing threads there, so the avatar
+            column would just be an empty strip down the left of every post. */}
+        <Box pl={isCommentRow ? `${THREAD_CONTENT_OFFSET_PX}px` : 0}>
+          <Box sx={{ p: { marginBottom: "1rem", lineHeight: "1.6" } }}>
+            <EnhancedMarkdownRenderer content={text} />
+          </Box>
 
-        {!showSlider && (
-          <HStack
-            justify="space-between"
-            // Tighter above the action bar on nested comments; posts keep the original spacing
-            mt={effectiveDepth > 1 ? 1 : 3}
-            w="100%"
-            px={4}
-          >
-            <HStack spacing={6}>
-              <HStack
-                justify="center"
-                px={2}
-                py={1}
-                cursor="pointer"
-                role="button"
-                tabIndex={0}
-                onClick={() => {
-                  if (!voted && !isVoting) {
-                    if (disableSlider) {
-                      // Slider disabled - vote directly with default weight
-                      handleDirectVote();
-                    } else {
-                      // Show slider for vote weight selection
-                      setShowSlider(true);
-                    }
-                  }
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    if (e.key === " ") e.preventDefault();
+          {!showSlider && (
+            <HStack
+              justify="space-between"
+              mt={2}
+              // On a comment, pull back the first action's own px so the icons
+              // line up with the author name and body above them. A feed post
+              // has no column to line up with, so it keeps the inset the action
+              // bar has always had there.
+              ml={isCommentRow ? -2 : 2}
+              mr={isCommentRow ? 0 : 2}
+            >
+              <HStack spacing={2}>
+                <HStack
+                  justify="center"
+                  px={2}
+                  py={1}
+                  cursor="pointer"
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => {
                     if (!voted && !isVoting) {
                       if (disableSlider) {
                         // Slider disabled - vote directly with default weight
@@ -525,271 +596,298 @@ const Snap = React.memo(function Snap({
                         setShowSlider(true);
                       }
                     }
-                  }
-                }}
-                opacity={isVoting ? 0.5 : 0.9}
-                _hover={{ opacity: 0.7 }}
-                transition="opacity 0.2s"
-              >
-                <HStack spacing={1}>
-                  {voted ? (
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      if (e.key === " ") e.preventDefault();
+                      if (!voted && !isVoting) {
+                        if (disableSlider) {
+                          // Slider disabled - vote directly with default weight
+                          handleDirectVote();
+                        } else {
+                          // Show slider for vote weight selection
+                          setShowSlider(true);
+                        }
+                      }
+                    }
+                  }}
+                  opacity={isVoting ? 0.5 : 0.9}
+                  _hover={{ opacity: 0.7 }}
+                  transition="opacity 0.2s"
+                >
+                  <HStack spacing={1}>
+                    {voted ? (
+                      <Box boxSize="18px" display="flex" alignItems="center" justifyContent="center">
+                        <LuCheck size={18} color="var(--chakra-colors-primary)" />
+                      </Box>
+                    ) : (
+                      <Box boxSize="18px" display="flex" alignItems="center" justifyContent="center">
+                        <LuArrowUp size={18} color="var(--chakra-colors-text)" />
+                      </Box>
+                    )}
+                    {activeVotes.length > 0 && (
+                      <Text
+                        fontSize="sm"
+                        fontWeight="medium"
+                        color={voted ? "primary" : "text"}
+                      >
+                        {activeVotes.length}
+                      </Text>
+                    )}
+                  </HStack>
+                </HStack>
+
+                <HStack
+                  justify="center"
+                  px={2}
+                  py={1}
+                  cursor="pointer"
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => {
+                    // Always open inline composer for replies
+                    handleReplyButtonClick(discussion.permlink);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      if (e.key === " ") e.preventDefault();
+                      // Always open inline composer for replies
+                      handleReplyButtonClick(discussion.permlink);
+                    }
+                  }}
+                  opacity={0.9}
+                  _hover={{ opacity: 0.7 }}
+                  transition="opacity 0.2s"
+                >
+                  <HStack spacing={1.5}>
                     <Box boxSize="18px" display="flex" alignItems="center" justifyContent="center">
-                      <LuCheck size={18} color="var(--chakra-colors-primary)" />
+                      <FaRegComment
+                        size={18}
+                        color={voted ? "var(--chakra-colors-primary)" : "var(--chakra-colors-text)"}
+                      />
                     </Box>
-                  ) : (
-                    <Box boxSize="18px" display="flex" alignItems="center" justifyContent="center">
-                      <LuArrowUp size={18} color="var(--chakra-colors-text)" />
-                    </Box>
-                  )}
-                  {activeVotes.length > 0 && (
                     <Text
                       fontSize="sm"
                       fontWeight="medium"
                       color={voted ? "primary" : "text"}
                     >
-                      {activeVotes.length}
+                      {commentCount}
                     </Text>
-                  )}
-                </HStack>
-              </HStack>
-
-              <Box color="gray.600" fontSize="sm" userSelect="none">|</Box>
-
-              <HStack
-                justify="center"
-                px={2}
-                py={1}
-                cursor="pointer"
-                role="button"
-                tabIndex={0}
-                onClick={() => {
-                  // Always open inline composer for replies
-                  handleReplyButtonClick(discussion.permlink);
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    if (e.key === " ") e.preventDefault();
-                    // Always open inline composer for replies
-                    handleReplyButtonClick(discussion.permlink);
-                  }
-                }}
-                opacity={0.9}
-                _hover={{ opacity: 0.7 }}
-                transition="opacity 0.2s"
-              >
-                <HStack spacing={1.5}>
-                  <Box boxSize="18px" display="flex" alignItems="center" justifyContent="center">
-                    <FaRegComment
-                      size={18}
-                      color={voted ? "var(--chakra-colors-primary)" : "var(--chakra-colors-text)"}
-                    />
-                  </Box>
-                  <Text
-                    fontSize="sm"
-                    fontWeight="medium"
-                    color={voted ? "primary" : "text"}
-                  >
-                    {commentCount}
-                  </Text>
-                </HStack>
-              </HStack>
-
-              {showSponsorCTA && (
-                <Tooltip
-                  label="Sponsor this user to create their Hive account"
-                  hasArrow
-                  placement="top"
-                >
-                  <HStack
-                    minW="72px"
-                    justify="center"
-                    px={2}
-                    py={1}
-                    borderRadius="md"
-                    cursor="pointer"
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => setIsSponsorModalOpen(true)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        if (e.key === " ") e.preventDefault();
-                        setIsSponsorModalOpen(true);
-                      }
-                    }}
-                    opacity={0.9}
-                    _hover={{ opacity: 0.7 }}
-                    transition="opacity 0.2s"
-                  >
-                    <HStack spacing={1.5}>
-                      <Box boxSize="18px" display="flex" alignItems="center" justifyContent="center">
-                        <FaGift size={18} color="var(--chakra-colors-primary)" />
-                      </Box>
-                      <Text
-                        fontSize="sm"
-                        fontWeight="medium"
-                        color="green.500"
-                      >
-                        Sponsor
-                      </Text>
-                    </HStack>
                   </HStack>
-                </Tooltip>
-              )}
-            </HStack>
+                </HStack>
 
-            <Tooltip
-              label={
-                isPending
-                  ? `Pending - ${daysRemaining} day${
-                      daysRemaining !== 1 ? "s" : ""
-                    } until payout - Click to see voters`
-                  : `Author: $${authorPayout.toFixed(
-                      3
-                    )} | Curators: $${curatorPayout.toFixed(3)} - Click to see voters`
-              }
-              hasArrow
-              openDelay={500}
-              placement="top"
-            >
-              <Box>
-                <VoteListPopover
-                  trigger={
+                {showSponsorCTA && (
+                  <Tooltip
+                    label="Sponsor this user to create their Hive account"
+                    hasArrow
+                    placement="top"
+                  >
                     <HStack
+                      minW="72px"
                       justify="center"
                       px={2}
                       py={1}
+                      borderRadius="md"
                       cursor="pointer"
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => setIsSponsorModalOpen(true)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          if (e.key === " ") e.preventDefault();
+                          setIsSponsorModalOpen(true);
+                        }
+                      }}
                       opacity={0.9}
                       _hover={{ opacity: 0.7 }}
                       transition="opacity 0.2s"
                     >
-                      <HStack spacing={0.5}>
+                      <HStack spacing={1.5}>
+                        <Box boxSize="18px" display="flex" alignItems="center" justifyContent="center">
+                          <FaGift size={18} color="var(--chakra-colors-primary)" />
+                        </Box>
                         <Text
                           fontSize="sm"
                           fontWeight="medium"
-                          color={voted ? "primary" : "text"}
+                          color="green.500"
                         >
-                          $
-                        </Text>
-                        <Text
-                          fontSize="sm"
-                          fontWeight="medium"
-                          color={voted ? "primary" : "text"}
-                        >
-                          {rewardAmount.toFixed(2)}
+                          Sponsor
                         </Text>
                       </HStack>
                     </HStack>
-                  }
-                  votes={activeVotes}
-                  post={discussion}
-                />
-              </Box>
-            </Tooltip>
-          </HStack>
-        )}
+                  </Tooltip>
+                )}
+              </HStack>
 
-        {showSlider && (
-          <ErrorBoundaryWithReport>
-            <UpvoteButton
-              discussion={discussion}
-              voted={voted}
-              setVoted={setVotedOverride}
-              activeVotes={activeVotes}
-              setActiveVotes={setActiveVotes}
-              showSlider={showSlider}
-              setShowSlider={setShowSlider}
-              onVoteSuccess={(estimatedValue?: number) => {
-                setVotedOverride(true);
-                if (estimatedValue) {
-                  setRewardAmount((prev) =>
-                    parseFloat((prev + estimatedValue).toFixed(3))
-                  );
+              <Tooltip
+                label={
+                  isPending
+                    ? `Pending - ${daysRemaining} day${
+                        daysRemaining !== 1 ? "s" : ""
+                      } until payout - Click to see voters`
+                    : `Author: $${authorPayout.toFixed(
+                        3
+                      )} | Curators: $${curatorPayout.toFixed(3)} - Click to see voters`
                 }
-              }}
-              estimateVoteValue={estimateVoteValue}
-              isHivePowerLoading={isHivePowerLoading}
-              variant="withSlider"
-              size="sm"
-            />
-          </ErrorBoundaryWithReport>
-        )}
-        {inlineComposerStates[discussion.permlink] && (
-          <Box mt={2}>
-            {inlineRepliesMap[discussion.permlink] &&
-              inlineRepliesMap[discussion.permlink].length > 0 && (
-                <VStack spacing={2} align="stretch" mt={3} mb={2} pl={2}>
-                  {inlineRepliesMap[discussion.permlink].map(
-                    (reply: Discussion) => {
-                      const nextDepth = effectiveDepth + 1;
-                      return (
-                        <Snap
-                          key={`${reply.author}/${reply.permlink}`}
-                          discussion={{ ...reply, depth: nextDepth } as any}
-                          onOpen={onOpen}
-                          setReply={setReply}
-                          setConversation={setConversation}
-                          onDelete={onDelete}
-                        />
-                      );
+                hasArrow
+                openDelay={500}
+                placement="top"
+              >
+                <Box>
+                  <VoteListPopover
+                    trigger={
+                      <HStack
+                        justify="center"
+                        px={2}
+                        py={1}
+                        cursor="pointer"
+                        opacity={0.9}
+                        _hover={{ opacity: 0.7 }}
+                        transition="opacity 0.2s"
+                      >
+                        <HStack spacing={0.5}>
+                          <Text
+                            fontSize="sm"
+                            fontWeight="medium"
+                            color={voted ? "primary" : "text"}
+                          >
+                            $
+                          </Text>
+                          <Text
+                            fontSize="sm"
+                            fontWeight="medium"
+                            color={voted ? "primary" : "text"}
+                          >
+                            {rewardAmount.toFixed(2)}
+                          </Text>
+                        </HStack>
+                      </HStack>
                     }
-                  )}
-                </VStack>
-              )}
-            <SnapComposer
-              pa={discussion.author}
-              pp={discussion.permlink}
-              onNewComment={handleInlineNewReply}
-              onClose={() =>
-                setInlineComposerStates((prev: Record<string, boolean>) => ({
-                  ...prev,
-                  [discussion.permlink]: false,
-                }))
-              }
-              post
-              isReply
-            />
-          </Box>
-        )}
+                    votes={activeVotes}
+                    post={discussion}
+                  />
+                </Box>
+              </Tooltip>
+            </HStack>
+          )}
 
-        {/* Sponsorship Modal */}
-        {showSponsorCTA && softPost?.user && softPost.user.handle && viewerHiveUsername && (
-          <SponsorshipModal
-            isOpen={isSponsorModalOpen}
-            onClose={() => setIsSponsorModalOpen(false)}
-            liteUserId={softPost.user.id}
-            liteUserHandle={softPost.user.handle}
-            liteUserDisplayName={softPost.user.handle || softPost.user.display_name || 'User'}
-            sponsorHiveUsername={viewerHiveUsername}
-          />
-        )}
-
-        {/* Instagram force-post preview (moderator only). Lazy: only
-            mounted while open so we don't preflight a fetch for every
-            snap that has a 3-dots menu rendered on screen. */}
-        {isModerator && isIgPreviewOpen && (
-          <InstagramPreviewModal
-            isOpen={isIgPreviewOpen}
-            onClose={() => setIsIgPreviewOpen(false)}
-            mode="moderator"
-            context={{
-              hiveAuthor: discussion.author,
-              hivePermlink: discussion.permlink,
-              title: (discussion as any).title || "",
-              body: discussion.body,
-              tags: Array.isArray((discussion as any).json_metadata?.tags)
-                ? (discussion as any).json_metadata.tags
-                : [],
-              imageUrl: igMedia.image,
-              videoUrl: igMedia.video,
-              permalinkUrl: `${
-                typeof window !== "undefined" ? window.location.origin : "https://skatehive.app"
-              }/post/${discussion.author}/${discussion.permlink}`,
-            }}
-            userHandle={walletUser || effectiveUser}
-          />
-        )}
+          {showSlider && (
+            <ErrorBoundaryWithReport>
+              <UpvoteButton
+                discussion={discussion}
+                voted={voted}
+                setVoted={setVotedOverride}
+                activeVotes={activeVotes}
+                setActiveVotes={setActiveVotes}
+                showSlider={showSlider}
+                setShowSlider={setShowSlider}
+                onVoteSuccess={(estimatedValue?: number) => {
+                  setVotedOverride(true);
+                  if (estimatedValue) {
+                    setRewardAmount((prev) =>
+                      parseFloat((prev + estimatedValue).toFixed(3))
+                    );
+                  }
+                }}
+                estimateVoteValue={estimateVoteValue}
+                isHivePowerLoading={isHivePowerLoading}
+                variant="withSlider"
+                size="sm"
+              />
+            </ErrorBoundaryWithReport>
+          )}
+        </Box>
       </Box>
+
+      {/* Reply group, flush with this row: a reply sits directly under the
+          comment it answers, in the same avatar column, so the connector
+          between them runs straight down the middle of that column. */}
+      {isThreadOpen && (
+        <Box mt={2}>
+          {inlineReplies.length > 0 && (
+            <VStack spacing={2} align="stretch" mb={2}>
+              {inlineReplies.map((reply: Discussion, index: number) => {
+                const nextDepth = effectiveDepth + 1;
+                return (
+                  <Snap
+                    key={`${reply.author}/${reply.permlink}`}
+                    discussion={{ ...reply, depth: nextDepth } as any}
+                    onOpen={onOpen}
+                    setReply={setReply}
+                    setConversation={setConversation}
+                    onDelete={onDelete}
+                    hasFollowingThreadRow={index < inlineReplies.length - 1}
+                    // A reply is always a comment, even when its parent is a
+                    // feed post.
+                    isCommentRow
+                  />
+                );
+              })}
+            </VStack>
+          )}
+          <SnapComposer
+            pa={discussion.author}
+            pp={discussion.permlink}
+            onNewComment={handleInlineNewReply}
+            onClose={() =>
+              setInlineComposerStates((prev: Record<string, boolean>) => ({
+                ...prev,
+                [discussion.permlink]: false,
+              }))
+            }
+            post
+            isReply
+          />
+        </Box>
+      )}
+
+      <EditPostModal
+        isOpen={isEditing}
+        onClose={handleCancelEdit}
+        discussion={discussion}
+        editedContent={editedContent}
+        setEditedContent={setEditedContent}
+        onSave={handleSaveEdit}
+        isSaving={isSaving}
+      />
+
+      {/* Sponsorship Modal */}
+      {showSponsorCTA && softPost?.user && softPost.user.handle && viewerHiveUsername && (
+        <SponsorshipModal
+          isOpen={isSponsorModalOpen}
+          onClose={() => setIsSponsorModalOpen(false)}
+          liteUserId={softPost.user.id}
+          liteUserHandle={softPost.user.handle}
+          liteUserDisplayName={softPost.user.handle || softPost.user.display_name || 'User'}
+          sponsorHiveUsername={viewerHiveUsername}
+        />
+      )}
+
+      {/* Instagram force-post preview (moderator only). Lazy: only
+          mounted while open so we don't preflight a fetch for every
+          snap that has a 3-dots menu rendered on screen. */}
+      {isModerator && isIgPreviewOpen && (
+        <InstagramPreviewModal
+          isOpen={isIgPreviewOpen}
+          onClose={() => setIsIgPreviewOpen(false)}
+          mode="moderator"
+          context={{
+            hiveAuthor: discussion.author,
+            hivePermlink: discussion.permlink,
+            title: (discussion as any).title || "",
+            body: discussion.body,
+            tags: Array.isArray((discussion as any).json_metadata?.tags)
+              ? (discussion as any).json_metadata.tags
+              : [],
+            imageUrl: igMedia.image,
+            videoUrl: igMedia.video,
+            permalinkUrl: `${
+              typeof window !== "undefined" ? window.location.origin : "https://skatehive.app"
+            }/post/${discussion.author}/${discussion.permlink}`,
+          }}
+          userHandle={walletUser || effectiveUser}
+        />
+      )}
     </Box>
   );
 });

--- a/components/homepage/SnapList.tsx
+++ b/components/homepage/SnapList.tsx
@@ -37,6 +37,13 @@ interface SnapListProps {
   post?: boolean;
   data: InfiniteScrollData;
   hideComposer?: boolean;
+  /**
+   * Render the list as one conversation: rows are chained by the thread
+   * connector and the separators between them are dropped. Off by default —
+   * `post` alone is not enough, since bounty submissions are also comments on
+   * a post yet are independent entries rather than a discussion.
+   */
+  threadComments?: boolean;
 }
 
 interface InfiniteScrollData {
@@ -57,6 +64,7 @@ export default function SnapList({
   post = false,
   data,
   hideComposer = false,
+  threadComments = false,
 }: SnapListProps) {
   const { comments, loadNextPage, isLoading, hasMore } = data;
   const [displayedComments, setDisplayedComments] = useState<Discussion[]>([]);
@@ -390,18 +398,32 @@ export default function SnapList({
                 <VStack
                   spacing={1}
                   align="stretch"
-                  divider={<Box borderBottom="1px solid" borderColor="muted" />}
+                  // A threaded list is one conversation, so the connector is
+                  // what relates the rows; keeping the rules as well would say
+                  // "separate" and "chained" at the same time.
+                  divider={
+                    threadComments ? undefined : (
+                      <Box borderBottom="1px solid" borderColor="muted" />
+                    )
+                  }
                 >
-                  {filteredAndSortedComments.map((discussion: Discussion) => (
-                    <Snap
-                      key={discussion.permlink}
-                      discussion={discussion}
-                      onOpen={onOpenConversation}
-                      setReply={setReply}
-                      {...(!post ? { setConversation } : {})}
-                      onDelete={handleDeleteComment}
-                    />
-                  ))}
+                  {filteredAndSortedComments.map(
+                    (discussion: Discussion, index: number) => (
+                      <Snap
+                        key={discussion.permlink}
+                        discussion={discussion}
+                        onOpen={onOpenConversation}
+                        setReply={setReply}
+                        {...(!post ? { setConversation } : {})}
+                        onDelete={handleDeleteComment}
+                        isCommentRow={threadComments}
+                        hasFollowingThreadRow={
+                          threadComments &&
+                          index < filteredAndSortedComments.length - 1
+                        }
+                      />
+                    )
+                  )}
                 </VStack>
               </SoftVoteProvider>
             </SoftPostProvider>


### PR DESCRIPTION
Closes #227

The action bar rendered a bare `|` glyph between the upvote and the comment count, which read as a broken divider rather than a separator. Removing it turned into a small redesign of how a comment thread reads.

## What changes

A post's comments are now chained by a connector that runs between avatars: it starts under the first comment, passes behind the avatars in between, and stops on the last. A reply sits in the same avatar column as the comment it answers, directly beneath it, so the line between them is straight and centred.

Replies are never indented per level. There is no offset to accumulate, so a deep reply chain cannot cascade off the right edge — which is what sank the previous attempt at threading here.

## Scope: the feed is untouched

Everything the avatar column implies — the connector and the indent that aligns media, body and actions under the author name — is behind `isCommentRow`. A post in the feed keeps the full width it has today and never draws a connector out of its author avatar, however many replies it has open. Only its header gains the avatar column.

Threading is opt-in per list, via `threadComments` on `SnapList`. "Comments on a post" is not the same thing as "one conversation": `BountyDetail` also passes `post={true}`, but bounty submissions are independent entries and must not be chained. A threaded list also drops the rules between rows, which would otherwise read as "separate" while the connector reads as "chained".

## Two decisions worth knowing

- **Comment media is indented rather than full-bleed.** Full-bleed media is opaque and hundreds of pixels tall; it would hide the connector for that whole stretch and the chain would render as two disconnected stubs on any comment carrying a video. Feed media is unaffected.
- **The connector colour is a neutral translucent grey**, not the theme text colour. `text` is `#00FF00` on the hacker themes, which made the line read as a bright green rule instead of a quiet hairline.

## Worth checking

- A comment **with a video** — the line should be continuous, not cut into stubs.
- A **bounty** page — submissions should stay separated, with their rules, and no connector.
- The **feed** — posts should fill the full width in media, caption and action bar.
- A light theme (`paper`, `whiteblack`) — the connector adapts via `useColorModeValue`.

Layout only: no handler, state, data flow or async path was touched. `tsc` and `next lint` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added threaded comment display with aligned avatars and vertical connection lines.
  - Grouped replies directly beneath their parent comments for clearer conversations.
  - Preserved existing feed post layouts when threaded comments are not enabled.

- **UI Improvements**
  - Refined comment media, content, and action-bar alignment.
  - Removed unnecessary separators while retaining voting, replies, payouts, sponsorship, and moderation controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
