### PR TITLE
fix(portfolio): read ERC-20 balances from the chain and merge over the upstream

### DIFF
--- a/app/api/portfolio/[address]/route.ts
+++ b/app/api/portfolio/[address]/route.ts
@@ -5,6 +5,7 @@ import {
   fetchNativeEthBalances,
   type NativeEthBalance,
 } from "@/lib/evm/nativeEthBalances";
+import { fetchErc20Balances, type Erc20Balance } from "@/lib/evm/erc20Balances";
 
 const SUPPORTED_NATIVE_ETH_CHAIN_IDS = new Set([1, 8453, 42161]);
 
@@ -287,13 +288,85 @@ export async function GET(
           sum + token.token.balanceUSD,
         0,
       );
-    const mergedTokens = [
-      ...transformedTokens.filter(
-        (token: Parameters<typeof isSupportedNativeEthToken>[0]) =>
-          !isSupportedNativeEthToken(token),
-      ),
-      ...nativeEthTokens,
-    ];
+    // ── ERC-20 from the chain (Alchemy), merged over the upstream ──────────
+    // Same idea as the native-ETH override above: the upstream is stale and
+    // has no mainnet ERC-20 coverage (it missed 1.01 stETH ≈ $2.4k on the
+    // treasury Safe). Rules: on-chain wins per (chain, contract); upstream-only
+    // tokens are kept; a failed chain keeps upstream untouched for that chain.
+    const normalizeNetworkName = (raw: unknown): string => {
+      const n = String(raw ?? "").toLowerCase();
+      if (n === "eth" || n === "mainnet" || n.includes("ethereum")) return "ethereum";
+      if (n.includes("arbitrum")) return "arbitrum";
+      if (n.includes("base")) return "base";
+      return n;
+    };
+    const erc20Results = isEvmAddress
+      ? await fetchErc20Balances(address as Address, alchemyApiKey, ethPriceUsd)
+      : [];
+    const erc20ToToken = (t: Erc20Balance) => {
+      const now = new Date().toISOString();
+      const id = `${t.network}-${t.address}`;
+      return {
+        address: t.address,
+        assetCaip: `eip155:${t.chainId}/erc20:${t.address}`,
+        key: id,
+        network: t.network,
+        token: {
+          address: t.address,
+          balance: t.balance,
+          balanceRaw: t.balanceRaw,
+          balanceUSD: t.balanceUSD,
+          canExchange: false,
+          coingeckoId: "",
+          createdAt: now,
+          decimals: t.decimals,
+          externallyVerified: false,
+          hide: false,
+          holdersEnabled: false,
+          id,
+          label: null,
+          name: t.name,
+          networkId: t.chainId,
+          price: t.price,
+          priceUpdatedAt: now,
+          status: "active",
+          symbol: t.symbol,
+          totalSupply: "0",
+          updatedAt: now,
+          verified: false,
+          ...(t.logo ? { imageUrlV2: t.logo } : {}),
+        },
+        updatedAt: now,
+      };
+    };
+    const upstreamErc20 = transformedTokens.filter(
+      (token: Parameters<typeof isSupportedNativeEthToken>[0]) =>
+        !isSupportedNativeEthToken(token),
+    );
+    const tokenKey = (network: unknown, addr: unknown) => `${normalizeNetworkName(network)}:${String(addr ?? "").toLowerCase()}`;
+    const byKey = new Map<string, any>();
+    for (const token of upstreamErc20) byKey.set(tokenKey(token.network, token.address), token);
+    let onChainOverrides = 0;
+    let onChainNew = 0;
+    for (const result of erc20Results) {
+      if (!result.ok) continue; // keep upstream for that chain, and never as zero
+      for (const t of result.tokens) {
+        const k = tokenKey(t.network, t.address);
+        const upstream = byKey.get(k);
+        if (upstream) onChainOverrides++; else onChainNew++;
+        // Balance always from chain. Price: CoinGecko when it answered; else
+        // the upstream's price for the same (chain, contract) — a stale price
+        // beats USD 0, which would hide a real holding behind the dust filter.
+        const price = t.price > 0 ? t.price : Number(upstream?.token?.price ?? 0);
+        byKey.set(k, erc20ToToken({ ...t, price, balanceUSD: t.balance * price }));
+      }
+    }
+    console.info(
+      `[Portfolio API] ERC-20 merge for ${address}: upstream=${upstreamErc20.length} ` +
+        erc20Results.map((r) => `${r.network}:${r.ok ? r.tokens.length : "FAILED"}`).join(",") +
+        ` → overrides=${onChainOverrides} new=${onChainNew}`,
+    );
+    const mergedTokens = [...byKey.values(), ...nativeEthTokens];
     const nativeEthUsd = nativeEthTokens.reduce(
       (sum, token) => sum + token.token.balanceUSD,
       0,
@@ -358,9 +431,11 @@ export async function GET(
           0
         )
     );
+    // Token total = what the list actually shows (on-chain native + merged
+    // ERC-20), not the upstream's stale figure.
     const totalBalanceUsdTokens = Math.max(
       0,
-      indexedTokenTotal - indexedNativeEthUsd + nativeEthUsd,
+      mergedTokens.reduce((sum: number, token: any) => sum + (Number(token.token?.balanceUSD) || 0), 0),
     );
     const totalBalanceUSDApp = Number(rawData.totalBalanceUSDApp ?? 0);
     const indexedNetWorth = Number(

--- a/lib/evm/erc20Balances.ts
+++ b/lib/evm/erc20Balances.ts
@@ -1,0 +1,169 @@
+import { formatUnits, type Address } from "viem";
+
+/**
+ * ERC-20 balances straight from the chain (Alchemy), for the same three
+ * chains as lib/evm/nativeEthBalances.ts.
+ *
+ * Why: the portfolio upstream (api.keepkey.info → Zapper) has no mainnet
+ * ERC-20 coverage for some addresses and serves stale balances. Verified on
+ * 2026-08-22 with the treasury Safe: upstream returned 29 Base tokens, zero
+ * mainnet tokens, and native ETH numbers from days earlier, while
+ * alchemy_getTokenBalances showed 1.01286565 stETH (~$2.45k) on mainnet.
+ *
+ * Contract: one result per chain. `ok: false` means the lookup FAILED — the
+ * caller must keep whatever the upstream had for that chain and must not
+ * treat it as "no tokens". Tokens without a price come back with price 0 so
+ * the client's Hide Dust filter hides them like any other unpriced token.
+ */
+
+export type Erc20Network = "arbitrum" | "base" | "ethereum";
+
+export interface Erc20Balance {
+  chainId: number;
+  network: Erc20Network;
+  address: string; // lowercase contract address
+  symbol: string;
+  name: string;
+  decimals: number;
+  balance: number;
+  balanceRaw: string;
+  price: number; // USD, 0 when unknown
+  balanceUSD: number;
+  logo?: string;
+}
+
+export interface Erc20ChainResult {
+  chainId: number;
+  network: Erc20Network;
+  ok: boolean;
+  tokens: Erc20Balance[];
+  error?: string;
+}
+
+const erc20Chains = [
+  { chainId: 1, network: "ethereum" as const, alchemySubdomain: "eth-mainnet", coingeckoPlatform: "ethereum" },
+  { chainId: 8453, network: "base" as const, alchemySubdomain: "base-mainnet", coingeckoPlatform: "base" },
+  { chainId: 42161, network: "arbitrum" as const, alchemySubdomain: "arb-mainnet", coingeckoPlatform: "arbitrum-one" },
+] as const;
+
+/** Lido stETH tracks ETH ~1:1; used ONLY when CoinGecko has no price for it. */
+const STETH_MAINNET = "0xae7ab96520de3a18e5e111b5eaab095312d7fe84";
+
+const ZERO_32 = "0x" + "0".repeat(64);
+
+async function rpc<T>(url: string, body: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+    // Balances change on every tx; never serve a cached answer here.
+    cache: "no-store",
+  });
+  if (!res.ok) throw new Error(`Alchemy HTTP ${res.status}`);
+  return (await res.json()) as T;
+}
+
+interface TokenBalanceEntry { contractAddress: string; tokenBalance: string | null; error?: string | null }
+interface TokenMetadata { symbol?: string | null; name?: string | null; decimals?: number | null; logo?: string | null }
+
+async function fetchTokenPricesUsd(platform: string, addresses: string[]): Promise<Record<string, number>> {
+  const out: Record<string, number> = {};
+  // Small batches: one bad/unknown contract in a long list makes CoinGecko
+  // answer 400 for the whole request. Free tier; on failure the caller falls
+  // back to the upstream price, then to USD 0 (hidden by the dust filter).
+  const CHUNK = 10;
+  for (let i = 0; i < addresses.length; i += CHUNK) {
+    const chunk = addresses.slice(i, i + CHUNK);
+    try {
+      const url = `https://api.coingecko.com/api/v3/simple/token_price/${platform}?contract_addresses=${chunk.join(",")}&vs_currencies=usd`;
+      const res = await fetch(url, { headers: { accept: "application/json" }, next: { revalidate: 60 } });
+      if (!res.ok) throw new Error(`CoinGecko HTTP ${res.status}`);
+      const data = (await res.json()) as Record<string, { usd?: number }>;
+      for (const [addr, v] of Object.entries(data)) {
+        if (typeof v?.usd === "number" && v.usd > 0) out[addr.toLowerCase()] = v.usd;
+      }
+    } catch (error) {
+      console.warn(`[Portfolio API] CoinGecko token prices failed on ${platform} (batch ${i / CHUNK + 1}):`, error instanceof Error ? error.message : error);
+    }
+  }
+  return out;
+}
+
+/**
+ * @param ethPriceUsd used only for the explicit stETH≈ETH fallback.
+ */
+export async function fetchErc20Balances(
+  address: Address,
+  alchemyApiKey: string | undefined,
+  ethPriceUsd: number,
+): Promise<Erc20ChainResult[]> {
+  if (!alchemyApiKey) {
+    console.error("[Portfolio API] No Alchemy key — ERC-20 on-chain lookup skipped, upstream only");
+    return erc20Chains.map((c) => ({ chainId: c.chainId, network: c.network, ok: false, tokens: [], error: "no alchemy key" }));
+  }
+
+  return Promise.all(
+    erc20Chains.map(async ({ chainId, network, alchemySubdomain, coingeckoPlatform }): Promise<Erc20ChainResult> => {
+      const url = `https://${alchemySubdomain}.g.alchemy.com/v2/${alchemyApiKey}`;
+      try {
+        // 1) balances (paginated)
+        const entries: TokenBalanceEntry[] = [];
+        let pageKey: string | undefined;
+        for (let page = 0; page < 5; page++) {
+          const r = await rpc<{ result?: { tokenBalances: TokenBalanceEntry[]; pageKey?: string }; error?: { message: string } }>(url, {
+            jsonrpc: "2.0", id: 1, method: "alchemy_getTokenBalances",
+            params: pageKey ? [address, "erc20", { pageKey }] : [address, "erc20"],
+          });
+          if (r.error) throw new Error(r.error.message);
+          entries.push(...(r.result?.tokenBalances ?? []));
+          pageKey = r.result?.pageKey;
+          if (!pageKey) break;
+        }
+        const nonZero = entries.filter((e) => e.tokenBalance && e.tokenBalance !== "0x0" && e.tokenBalance !== ZERO_32 && !e.error);
+        if (nonZero.length === 0) return { chainId, network, ok: true, tokens: [] };
+
+        // 2) metadata — one batched JSON-RPC request
+        const metaRes = await rpc<Array<{ id: number; result?: TokenMetadata; error?: { message: string } }>>(
+          url,
+          nonZero.map((e, i) => ({ jsonrpc: "2.0", id: i, method: "alchemy_getTokenMetadata", params: [e.contractAddress] })),
+        );
+        const metaById = new Map<number, TokenMetadata>();
+        for (const m of Array.isArray(metaRes) ? metaRes : []) if (m.result) metaById.set(m.id, m.result);
+
+        // 3) prices
+        const addrs = nonZero.map((e) => e.contractAddress.toLowerCase());
+        const prices = await fetchTokenPricesUsd(coingeckoPlatform, addrs);
+
+        const tokens: Erc20Balance[] = [];
+        nonZero.forEach((e, i) => {
+          const meta = metaById.get(i);
+          const decimals = typeof meta?.decimals === "number" ? meta.decimals : 18;
+          const contract = e.contractAddress.toLowerCase();
+          const raw = BigInt(e.tokenBalance as string);
+          const balance = Number(formatUnits(raw, decimals));
+          let price = prices[contract] ?? 0;
+          if (price === 0 && chainId === 1 && contract === STETH_MAINNET && ethPriceUsd > 0) {
+            // EXPLICIT approximation: stETH ≈ ETH (Lido rebasing token, trades
+            // within ~0.5% of ETH). Only used when CoinGecko gave no price.
+            price = ethPriceUsd;
+          }
+          // Names/symbols are untrusted on-chain strings (spam tokens embed
+          // URLs). They are rendered as plain text only — never as links.
+          const symbol = (meta?.symbol || "UNKNOWN").slice(0, 32);
+          const name = (meta?.name || symbol).slice(0, 80);
+          tokens.push({
+            chainId, network, address: contract, symbol, name, decimals,
+            balance, balanceRaw: raw.toString(), price, balanceUSD: balance * price,
+            logo: meta?.logo ?? undefined,
+          });
+        });
+        return { chainId, network, ok: true, tokens };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        // Loud: a failed chain means the list for that chain is upstream-only.
+        console.error(`[Portfolio API] ERC-20 on-chain lookup FAILED on ${network} — keeping upstream tokens for that chain: ${message}`);
+        return { chainId, network, ok: false, tokens: [], error: message };
+      }
+    }),
+  );
+}


### PR DESCRIPTION
## Problem
`/wallet` connected to the treasury Safe (`0xC1af…E218`) showed **TOTAL MONEY $35** while the Safe held ~$2.4k of stETH on mainnet.

`app/api/portfolio/[address]/route.ts` has no ERC-20 discovery of its own — it uses `api.keepkey.info` (Zapper). For this address the upstream returns 29 Base tokens, **zero mainnet tokens**, and stale balances (native ETH days old; USDC 16.21 vs 63.72 on-chain). The native-ETH half was already fixed by `lib/evm/nativeEthBalances.ts` (Alchemy override). This PR does the same for ERC-20.

## Change
- **`lib/evm/erc20Balances.ts`** (same pattern as `nativeEthBalances.ts`): per chain (1, 8453, 42161) `alchemy_getTokenBalances` (paginated) → `alchemy_getTokenMetadata` (one batched JSON-RPC) → CoinGecko `simple/token_price` in batches of 10. One result per chain with an explicit `ok` flag; a failed chain is logged loudly and is **never** treated as "no tokens".
- **Route merge rules**
  - dedup key = normalized network + lowercase contract (not symbol)
  - on-chain **wins** over upstream for the same key
  - upstream-only tokens are **kept** (no regression on the Base list)
  - failed chain → upstream untouched for that chain
  - price: CoinGecko; else the upstream's price for the same token (stale price beats USD 0, which would hide a real holding behind *Hide Dust*); stETH explicitly falls back to the ETH price (≈1:1) only when CoinGecko has nothing
  - `totalBalanceUsdTokens` = sum of what the list shows
- Names/symbols are untrusted on-chain strings (spam tokens embed URLs): plain text only, truncated, never links. Unpriced tokens carry USD 0 and fall under the existing *Hide Dust* filter.

## Verification (local, Safe address)
- stETH row present at the on-chain balance, CoinGecko price $2,416.74
- USDC kept — **63.7218** (on-chain; the upstream's 16.2149 was stale)
- TOTAL MONEY = sum of rows ($652.72 at capture time — the Safe had just sent 0.777 stETH out in tx `0xf9e13d70…`, so the expected ~$2,490 no longer holds on-chain; with 1.01286565 stETH the route computed $2,525)
- Route log: `ERC-20 merge … upstream=29 ethereum:1,base:31,arbitrum:0 → overrides=27 new=5`

Known: CoinGecko free tier 429s under load; fallbacks cover it. The ETH price used for native ETH still comes from the upstream (pre-existing, $2,032 vs ~$2,440 real) — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying ERC-20 token balances from Ethereum, Base, and Arbitrum.
  - Token balances, metadata, logos, and USD values are incorporated into portfolio views.
  - Portfolio totals now reflect the combined token data for more complete valuation.
  - Added pricing fallbacks for supported tokens when live pricing is unavailable.

- **Bug Fixes**
  - Preserved existing portfolio data when blockchain balance or pricing requests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->