### PR TITLE
fix(compose): scope draft storage per logged-in user

### DIFF
--- a/app/compose/page.tsx
+++ b/app/compose/page.tsx
@@ -40,10 +40,10 @@ import { ErrorBoundaryWithReport } from "@/components/shared/ErrorBoundary";
 import { useRouter } from "next/navigation";
 import { FaArrowLeft, FaFileAlt, FaSave } from "react-icons/fa";
 import {
-  ACTIVE_COMPOSE_DRAFT_KEY,
   ComposeDraft,
   createDraftId,
   createTemplateFromDraft,
+  getActiveComposeDraftId,
   getComposeDraft,
   getComposeTemplates,
   saveComposeTemplate,
@@ -200,7 +200,7 @@ export default function Composer() {
     (draftId?: string): ComposeDraft => {
       const now = new Date().toISOString();
       const id = draftId || activeDraftId || createDraftId();
-      const existingDraft = draftId || activeDraftId ? getComposeDraft(id) : null;
+      const existingDraft = draftId || activeDraftId ? getComposeDraft(id, user) : null;
 
       return {
         id,
@@ -222,6 +222,7 @@ export default function Composer() {
       selectedThumbnail,
       title,
       uploadedThumbnail,
+      user,
     ]
   );
 
@@ -230,11 +231,11 @@ export default function Composer() {
       if (!force && !hasDraftContent) return;
 
       const draft = buildDraft();
-      saveComposeDraft(draft);
+      saveComposeDraft(draft, user);
       setActiveDraftId(draft.id);
       setLastDraftSavedAt(draft.updatedAt);
     },
-    [buildDraft, hasDraftContent]
+    [buildDraft, hasDraftContent, user]
   );
 
   const handleSaveTemplate = useCallback(() => {
@@ -276,7 +277,7 @@ export default function Composer() {
     };
 
     if (draftId) {
-      const draft = getComposeDraft(draftId);
+      const draft = getComposeDraft(draftId, user);
       if (draft) {
         restoreDraft(draft);
       }
@@ -295,19 +296,31 @@ export default function Composer() {
     } else if (startsNewDraft) {
       setActiveDraftId(createDraftId());
     } else {
-      const storedDraftId = window.localStorage.getItem(ACTIVE_COMPOSE_DRAFT_KEY);
-      if (storedDraftId) {
-        const draft = getComposeDraft(storedDraftId);
-        if (draft) {
-          restoreDraft(draft);
-        } else {
-          setActiveDraftId(storedDraftId);
-        }
+      const storedDraftId = getActiveComposeDraftId(user);
+      const draft = storedDraftId ? getComposeDraft(storedDraftId, user) : null;
+
+      if (draft) {
+        restoreDraft(draft);
+      } else if (hasLoadedInitialDraft) {
+        // User switched accounts mid-session with no draft of their own —
+        // clear the previous user's in-memory content instead of leaking it.
+        setTitle("");
+        setMarkdown("");
+        setHashtags([]);
+        setHashtagInput("");
+        setBeneficiaries([]);
+        setSelectedThumbnail(null);
+        setUploadedThumbnail(null);
+        setActiveDraftId(storedDraftId || null);
+        setLastDraftSavedAt(null);
+      } else if (storedDraftId) {
+        setActiveDraftId(storedDraftId);
       }
     }
 
     setHasLoadedInitialDraft(true);
   }, [
+    hasLoadedInitialDraft,
     setBeneficiaries,
     setHashtagInput,
     setHashtags,
@@ -316,6 +329,7 @@ export default function Composer() {
     setTitle,
     setUploadedThumbnail,
     t,
+    user,
   ]);
 
   useEffect(() => {

--- a/app/compose/page.tsx
+++ b/app/compose/page.tsx
@@ -276,10 +276,27 @@ export default function Composer() {
       setLastDraftSavedAt(draft.updatedAt);
     };
 
+    const clearDraftState = (nextActiveDraftId: string | null) => {
+      setTitle("");
+      setMarkdown("");
+      setHashtags([]);
+      setHashtagInput("");
+      setBeneficiaries([]);
+      setSelectedThumbnail(null);
+      setUploadedThumbnail(null);
+      setActiveDraftId(nextActiveDraftId);
+      setLastDraftSavedAt(null);
+    };
+
     if (draftId) {
+      // A missing/unauthorized draft id (stale link, or another user's id
+      // after switching accounts) must not leave a prior user's content on
+      // screen.
       const draft = getComposeDraft(draftId, user);
       if (draft) {
         restoreDraft(draft);
+      } else {
+        clearDraftState(null);
       }
     } else if (templateId) {
       const template = getComposeTemplates().find((item) => item.id === templateId);
@@ -304,15 +321,7 @@ export default function Composer() {
       } else if (hasLoadedInitialDraft) {
         // User switched accounts mid-session with no draft of their own —
         // clear the previous user's in-memory content instead of leaking it.
-        setTitle("");
-        setMarkdown("");
-        setHashtags([]);
-        setHashtagInput("");
-        setBeneficiaries([]);
-        setSelectedThumbnail(null);
-        setUploadedThumbnail(null);
-        setActiveDraftId(storedDraftId || null);
-        setLastDraftSavedAt(null);
+        clearDraftState(storedDraftId || null);
       } else if (storedDraftId) {
         setActiveDraftId(storedDraftId);
       }

--- a/app/compose/workspace/page.tsx
+++ b/app/compose/workspace/page.tsx
@@ -18,7 +18,7 @@ import { useRouter } from "next/navigation";
 import { FaFileAlt, FaPen, FaRegClock, FaTrash } from "react-icons/fa";
 import { FiCopy } from "react-icons/fi";
 import { useLocale, useTranslations } from "@/contexts/LocaleContext";
-import useEffectiveHiveUser from "@/hooks/useEffectiveHiveUser";
+import { useComposeIdentity } from "@/hooks/useComposeIdentity";
 import {
   ComposeDraft,
   deleteComposeDraft,
@@ -43,7 +43,7 @@ export default function ComposeWorkspacePage() {
   const t = useTranslations();
   const { locale } = useLocale();
   const router = useRouter();
-  const { handle: user } = useEffectiveHiveUser();
+  const user = useComposeIdentity();
   const [drafts, setDrafts] = useState<ComposeDraft[]>([]);
   const [templates, setTemplates] = useState<ComposeTemplate[]>([]);
 

--- a/app/compose/workspace/page.tsx
+++ b/app/compose/workspace/page.tsx
@@ -18,6 +18,7 @@ import { useRouter } from "next/navigation";
 import { FaFileAlt, FaPen, FaRegClock, FaTrash } from "react-icons/fa";
 import { FiCopy } from "react-icons/fi";
 import { useLocale, useTranslations } from "@/contexts/LocaleContext";
+import useEffectiveHiveUser from "@/hooks/useEffectiveHiveUser";
 import {
   ComposeDraft,
   deleteComposeDraft,
@@ -42,13 +43,14 @@ export default function ComposeWorkspacePage() {
   const t = useTranslations();
   const { locale } = useLocale();
   const router = useRouter();
+  const { handle: user } = useEffectiveHiveUser();
   const [drafts, setDrafts] = useState<ComposeDraft[]>([]);
   const [templates, setTemplates] = useState<ComposeTemplate[]>([]);
 
   useEffect(() => {
-    setDrafts(readComposeDrafts());
+    setDrafts(readComposeDrafts(user));
     setTemplates(getComposeTemplates());
-  }, []);
+  }, [user]);
 
   const sortedDrafts = useMemo(() => {
     return [...drafts].sort(
@@ -57,8 +59,8 @@ export default function ComposeWorkspacePage() {
   }, [drafts]);
 
   const handleDeleteDraft = (id: string) => {
-    deleteComposeDraft(id);
-    setDrafts(readComposeDrafts());
+    deleteComposeDraft(id, user);
+    setDrafts(readComposeDrafts(user));
   };
 
   return (

--- a/hooks/useComposeIdentity.ts
+++ b/hooks/useComposeIdentity.ts
@@ -1,0 +1,14 @@
+import { useAioha } from "@aioha/react-ui";
+import { useLinkedIdentities } from "@/contexts/LinkedIdentityContext";
+import { useUserbaseAuth } from "@/contexts/UserbaseAuthContext";
+
+// The handle compose drafts are namespaced under: wallet/Keychain user first,
+// then the primary linked Hive identity, then a userbase-only handle. Shared
+// between the composer and the drafts list so both resolve the same bucket.
+export function useComposeIdentity(): string | null {
+  const { user } = useAioha();
+  const { hiveIdentity } = useLinkedIdentities();
+  const { user: userbaseUser } = useUserbaseAuth();
+
+  return user || hiveIdentity?.handle || userbaseUser?.handle || null;
+}

--- a/lib/compose/drafts.ts
+++ b/lib/compose/drafts.ts
@@ -9,11 +9,15 @@ export const COMPOSE_TEMPLATES_STORAGE_KEY = "skatehive.compose.templates.v1";
 const GUEST_DRAFT_NAMESPACE = "guest";
 
 function draftsKeyFor(userKey: string | null | undefined) {
-  return `${COMPOSE_DRAFTS_STORAGE_KEY}.${userKey || GUEST_DRAFT_NAMESPACE}`;
+  return userKey
+    ? `${COMPOSE_DRAFTS_STORAGE_KEY}.user.${encodeURIComponent(userKey)}`
+    : `${COMPOSE_DRAFTS_STORAGE_KEY}.${GUEST_DRAFT_NAMESPACE}`;
 }
 
 function activeDraftKeyFor(userKey: string | null | undefined) {
-  return `${ACTIVE_COMPOSE_DRAFT_KEY}.${userKey || GUEST_DRAFT_NAMESPACE}`;
+  return userKey
+    ? `${ACTIVE_COMPOSE_DRAFT_KEY}.user.${encodeURIComponent(userKey)}`
+    : `${ACTIVE_COMPOSE_DRAFT_KEY}.${GUEST_DRAFT_NAMESPACE}`;
 }
 
 export type ComposeDraft = {

--- a/lib/compose/drafts.ts
+++ b/lib/compose/drafts.ts
@@ -4,6 +4,18 @@ export const COMPOSE_DRAFTS_STORAGE_KEY = "skatehive.compose.drafts.v1";
 export const ACTIVE_COMPOSE_DRAFT_KEY = "skatehive.compose.activeDraftId.v1";
 export const COMPOSE_TEMPLATES_STORAGE_KEY = "skatehive.compose.templates.v1";
 
+// Drafts are namespaced per logged-in user so switching accounts on the same
+// browser never shows (or overwrites) another user's in-progress draft.
+const GUEST_DRAFT_NAMESPACE = "guest";
+
+function draftsKeyFor(userKey: string | null | undefined) {
+  return `${COMPOSE_DRAFTS_STORAGE_KEY}.${userKey || GUEST_DRAFT_NAMESPACE}`;
+}
+
+function activeDraftKeyFor(userKey: string | null | undefined) {
+  return `${ACTIVE_COMPOSE_DRAFT_KEY}.${userKey || GUEST_DRAFT_NAMESPACE}`;
+}
+
 export type ComposeDraft = {
   id: string;
   title: string;
@@ -57,11 +69,11 @@ export function createDraftId() {
   return `draft-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
-export function readComposeDrafts(): ComposeDraft[] {
+export function readComposeDrafts(userKey?: string | null): ComposeDraft[] {
   if (typeof window === "undefined") return [];
 
   try {
-    const raw = window.localStorage.getItem(COMPOSE_DRAFTS_STORAGE_KEY);
+    const raw = window.localStorage.getItem(draftsKeyFor(userKey));
     if (!raw) return [];
 
     const parsed = JSON.parse(raw);
@@ -83,34 +95,47 @@ export function readComposeDrafts(): ComposeDraft[] {
   }
 }
 
-export function writeComposeDrafts(drafts: ComposeDraft[]) {
+export function writeComposeDrafts(drafts: ComposeDraft[], userKey?: string | null) {
   if (typeof window === "undefined") return;
-  window.localStorage.setItem(COMPOSE_DRAFTS_STORAGE_KEY, JSON.stringify(drafts));
+  window.localStorage.setItem(draftsKeyFor(userKey), JSON.stringify(drafts));
 }
 
-export function saveComposeDraft(draft: ComposeDraft) {
-  const drafts = readComposeDrafts();
+export function saveComposeDraft(draft: ComposeDraft, userKey?: string | null) {
+  const drafts = readComposeDrafts(userKey);
   const nextDrafts = [
     draft,
     ...drafts.filter((existingDraft) => existingDraft.id !== draft.id),
   ].sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
 
-  writeComposeDrafts(nextDrafts);
-  window.localStorage.setItem(ACTIVE_COMPOSE_DRAFT_KEY, draft.id);
+  writeComposeDrafts(nextDrafts, userKey);
+  window.localStorage.setItem(activeDraftKeyFor(userKey), draft.id);
 
   return draft;
 }
 
-export function deleteComposeDraft(id: string) {
-  writeComposeDrafts(readComposeDrafts().filter((draft) => draft.id !== id));
+export function deleteComposeDraft(id: string, userKey?: string | null) {
+  writeComposeDrafts(
+    readComposeDrafts(userKey).filter((draft) => draft.id !== id),
+    userKey
+  );
 
-  if (window.localStorage.getItem(ACTIVE_COMPOSE_DRAFT_KEY) === id) {
-    window.localStorage.removeItem(ACTIVE_COMPOSE_DRAFT_KEY);
+  if (window.localStorage.getItem(activeDraftKeyFor(userKey)) === id) {
+    window.localStorage.removeItem(activeDraftKeyFor(userKey));
   }
 }
 
-export function getComposeDraft(id: string) {
-  return readComposeDrafts().find((draft) => draft.id === id) ?? null;
+export function getComposeDraft(id: string, userKey?: string | null) {
+  return readComposeDrafts(userKey).find((draft) => draft.id === id) ?? null;
+}
+
+export function getActiveComposeDraftId(userKey?: string | null): string | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage.getItem(activeDraftKeyFor(userKey));
+}
+
+export function clearActiveComposeDraftId(userKey?: string | null) {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(activeDraftKeyFor(userKey));
 }
 
 export function readComposeTemplates(): ComposeTemplate[] {


### PR DESCRIPTION
## What
Namespaces compose drafts (and the active-draft pointer) in localStorage by the current user's Hive handle instead of one shared key, falling back to a guest bucket when logged out.

## Why
Switching users on the same browser showed the previous user's in-progress draft, or silently overwrote it on save — confusing for multi-user setups.

## How to test
1. Log in as user A in `/compose`, type a draft, let it autosave (or wait for `beforeunload`/blur).
2. Log out and log in as user B.
3. Open `/compose` and `/compose/workspace` — user B should see a blank composer and only their own drafts, not user A's.
4. Log back in as user A — their draft should still be there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Compose drafts are now kept separate for each signed-in user.
  * Switching accounts no longer exposes or retains another user’s draft content.
  * Draft lists and active drafts refresh correctly when the current account changes.
  * Users without an existing draft for the new account see cleared compose content instead of stale content.
  * Invalid, missing, or unauthorized draft links now clear the editor rather than displaying previous draft content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->